### PR TITLE
state overhaul. fixes #60

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,21 @@
       "integrity": "sha512-rIuxC3DmMTtT/1ADUDzLRRYf0ux7xkT4YiwewyGFJzI7TDxTcqNkIC4cS4LoOb8OHxo9w/YjfsN9ffHnFn5tHQ==",
       "requires": {
         "dugite": "^1.82.0"
+      },
+      "dependencies": {
+        "dugite": {
+          "version": "1.87.0",
+          "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.87.0.tgz",
+          "integrity": "sha512-+aW2Ql3yw1AEO8Z8nVbjOAEzsinMJMmAg4uf5lzTewFUAHd0danuMPXMP9uMuGuUYN/LQtt4kR2XLuWoD8wRSQ==",
+          "requires": {
+            "checksum": "^0.1.1",
+            "mkdirp": "^0.5.1",
+            "progress": "^2.0.3",
+            "request": "^2.88.0",
+            "rimraf": "^2.5.4",
+            "tar": "^4.4.7"
+          }
+        }
       }
     },
     "@jest/console": {
@@ -1727,19 +1742,6 @@
       "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
       "dev": true
     },
-    "dugite": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/dugite/-/dugite-1.86.0.tgz",
-      "integrity": "sha512-NjW4OOZNGPszW4yxiLK0hJcPKSqFt0SmEN1xttuSWi0UeieALBl7o3b0xfbPnhwsM1dQn3ISsdh7CyEHzAR+6A==",
-      "requires": {
-        "checksum": "^0.1.1",
-        "mkdirp": "^0.5.1",
-        "progress": "^2.0.3",
-        "request": "^2.88.0",
-        "rimraf": "^2.5.4",
-        "tar": "^4.4.7"
-      }
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2399,9 +2401,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "requires": {
         "minipass": "^2.2.1"
       }
@@ -2430,24 +2432,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2457,12 +2463,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2471,34 +2479,40 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2507,25 +2521,29 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2534,13 +2552,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2556,7 +2576,8 @@
         },
         "glob": {
           "version": "7.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2570,13 +2591,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2585,7 +2608,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2594,7 +2618,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2604,18 +2629,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -2623,13 +2651,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -2637,12 +2667,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.3.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -2651,7 +2683,8 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2660,7 +2693,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -2668,13 +2702,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2685,7 +2721,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2703,7 +2740,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2713,13 +2751,15 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2729,7 +2769,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2741,18 +2782,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -2760,19 +2804,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2782,19 +2829,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2806,7 +2856,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2814,7 +2865,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2829,7 +2881,8 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2838,42 +2891,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -2883,7 +2943,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2892,7 +2953,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2900,13 +2962,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2921,13 +2985,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2936,12 +3002,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -3323,6 +3391,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
+    },
+    "immer": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-3.1.2.tgz",
+      "integrity": "sha512-pi8JuvJ9c+98DlpDms/o0YLLg5khP8Qzjd8CtIGc4qVm2eoLdQGivJL266nWccofKT/oBSxnhAh/o+nmOXtLXw=="
     },
     "import-fresh": {
       "version": "3.0.0",
@@ -6849,15 +6922,15 @@
       "dev": true
     },
     "synchronous-promise": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.8.tgz",
-      "integrity": "sha512-xYavZtFC1vKgJu0AOSYdrLeikNCsNwmUeZaV1XF9cMqEhBVVxLq6rEbYzOGrF1MV2MNPkhsJqqiXuQ4a76CEUg==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz",
+      "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
       "dev": true
     },
     "table": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.3.tgz",
-      "integrity": "sha512-3wUNCgdWX6PNpOe3amTTPWPuF6VGvgzjKCaO1snFj0z7Y3mUPWf5+zDtxUVGispJkDECPmR29wbzh6bVMOHbcw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -745,6 +745,11 @@
         "default-require-extensions": "^2.0.0"
       }
     },
+    "append-type": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/append-type/-/append-type-1.0.2.tgz",
+      "integrity": "sha512-hac740vT/SAbrFBLgLIWZqVT5PUAcGTWS5UkDDhr+OCizZSw90WKw6sWAEgGaYd2viIblggypMXwpjzHXOvAQg=="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -832,6 +837,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assert-valid-glob-opts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-valid-glob-opts/-/assert-valid-glob-opts-1.0.0.tgz",
+      "integrity": "sha512-/mttty5Xh7wE4o7ttKaUpBJl0l04xWe3y6muy1j27gyzSsnceK0AYU9owPtUoL9z8+9hnPxztmuhdFZ7jRoyWw==",
+      "requires": {
+        "glob-option-error": "^1.0.0",
+        "validate-glob-opts": "^1.0.0"
+      }
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -3094,6 +3108,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-option-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glob-option-error/-/glob-option-error-1.0.0.tgz",
+      "integrity": "sha1-V8xl3vnH1cFGG68TEpu1QDz/YXY="
+    },
     "globals": {
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
@@ -3142,8 +3161,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "growly": {
       "version": "1.3.0",
@@ -3429,6 +3447,14 @@
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
+    "indexed-filter": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/indexed-filter/-/indexed-filter-1.0.3.tgz",
+      "integrity": "sha512-oBIzs6EARNMzrLgVg20fK52H19WcRHBiukiiEkw9rnnI//8rinEBMLrYdwEfJ9d4K7bjV1L6nSGft6H/qzHNgQ==",
+      "requires": {
+        "append-type": "^1.0.1"
+      }
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3502,6 +3528,14 @@
             }
           }
         }
+      }
+    },
+    "inspect-with-kind": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
+      "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
+      "requires": {
+        "kind-of": "^6.0.2"
       }
     },
     "invariant": {
@@ -3706,6 +3740,11 @@
       "requires": {
         "path-is-inside": "^1.0.1"
       }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -4843,8 +4882,7 @@
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-      "dev": true
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
     },
     "kleur": {
       "version": "3.0.3",
@@ -6359,6 +6397,18 @@
         "glob": "^7.1.3"
       }
     },
+    "rmfr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rmfr/-/rmfr-2.0.0.tgz",
+      "integrity": "sha512-nQptLCZeyyJfgbpf2x97k5YE8vzDn7bhwx9NlvODdhgbU0mL1ruh71X0HYdRaOEvWC7Cr+SfV0p5p+Ib5yOl7A==",
+      "requires": {
+        "assert-valid-glob-opts": "^1.0.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "inspect-with-kind": "^1.0.4",
+        "rimraf": "^2.6.2"
+      }
+    },
     "rsvp": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
@@ -7304,6 +7354,24 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "validate-glob-opts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate-glob-opts/-/validate-glob-opts-1.0.2.tgz",
+      "integrity": "sha512-3PKjRQq/R514lUcG9OEiW0u9f7D4fP09A07kmk1JbNn2tfeQdAHhlT+A4dqERXKu2br2rrxSM3FzagaEeq9w+A==",
+      "requires": {
+        "array-to-sentence": "^1.1.0",
+        "indexed-filter": "^1.0.0",
+        "inspect-with-kind": "^1.0.4",
+        "is-plain-obj": "^1.1.0"
+      },
+      "dependencies": {
+        "array-to-sentence": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/array-to-sentence/-/array-to-sentence-1.1.0.tgz",
+          "integrity": "sha1-yASVba+lMjJJWyBalFJ1OiWNOfw="
+        }
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,72 +1,73 @@
 {
-	"name": "nori",
-	"version": "2.0.0-beta.3",
-	"description": "",
-	"bin": "src/index.js",
-	"scripts": {
-		"test": "npm run lint && npm run unit-test",
-		"unit-test": "jest",
-		"lint": "eslint src/ test/",
-		"lint-fix": "eslint --fix src/ test/",
-		"eslint-check": "eslint --print-config . | eslint-config-prettier-check"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:Financial-Times/transformation-runner.git"
-	},
-	"author": "",
-	"license": "MIT",
-	"dependencies": {
-		"@financial-times/git": "^1.0.0",
-		"@octokit/plugin-retry": "^2.2.0",
-		"@octokit/plugin-throttling": "^2.4.0",
-		"@octokit/rest": "^16.25.1",
-		"ansi-colors": "^3.2.4",
-		"array-to-sentence": "^2.0.0",
-		"enquirer": "^2.3.0",
-		"get-stdin": "^6.0.0",
-		"got": "^9.6.0",
-		"is-url": "^1.2.4",
-		"mkdirp": "^0.5.1",
-		"mz": "^2.7.0",
-		"parse-github-url": "^1.0.2",
-		"tiny-relative-date": "^1.3.0",
-		"yargs": "^13.2.2"
-	},
-	"devDependencies": {
-		"@quarterto/eslint-config": "^1.4.0",
-		"@quarterto/prettier": "^1.1.0",
-		"dotenv": "^7.0.0",
-		"eslint": "^5.16.0",
-		"eslint-config-prettier": "^4.1.0",
-		"eslint-plugin-no-only-tests": "^2.1.0",
-		"husky": "^2.3.0",
-		"jest": "^24.7.1",
-		"jest-junit": "^6.2.1",
-		"lint-staged": "^8.1.7",
-		"memfs": "^2.15.2",
-		"nock": "^10.0.6",
-		"precise-commits": "^1.0.2",
-		"prettier": "^1.17.0"
-	},
-	"engines": {
-		"node": "8.15.0"
-	},
-	"eslintConfig": {
-		"extends": [
-			"@quarterto"
-		]
-	},
-	"prettier": "@quarterto/prettier",
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"lint-staged": {
-		"*": [
-			"precise-commits",
-			"git add"
-		]
-	}
+  "name": "nori",
+  "version": "2.0.0-beta.3",
+  "description": "",
+  "bin": "src/index.js",
+  "scripts": {
+    "test": "npm run lint && npm run unit-test",
+    "unit-test": "jest",
+    "lint": "eslint src/ test/",
+    "lint-fix": "eslint --fix src/ test/",
+    "eslint-check": "eslint --print-config . | eslint-config-prettier-check"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Financial-Times/transformation-runner.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@financial-times/git": "^1.0.0",
+    "@octokit/plugin-retry": "^2.2.0",
+    "@octokit/plugin-throttling": "^2.4.0",
+    "@octokit/rest": "^16.25.1",
+    "ansi-colors": "^3.2.4",
+    "array-to-sentence": "^2.0.0",
+    "enquirer": "^2.3.0",
+    "get-stdin": "^6.0.0",
+    "got": "^9.6.0",
+    "immer": "^3.1.2",
+    "is-url": "^1.2.4",
+    "mkdirp": "^0.5.1",
+    "mz": "^2.7.0",
+    "parse-github-url": "^1.0.2",
+    "tiny-relative-date": "^1.3.0",
+    "yargs": "^13.2.2"
+  },
+  "devDependencies": {
+    "@quarterto/eslint-config": "^1.4.0",
+    "@quarterto/prettier": "^1.1.0",
+    "dotenv": "^7.0.0",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-no-only-tests": "^2.1.0",
+    "husky": "^2.3.0",
+    "jest": "^24.7.1",
+    "jest-junit": "^6.2.1",
+    "lint-staged": "^8.1.7",
+    "memfs": "^2.15.2",
+    "nock": "^10.0.6",
+    "precise-commits": "^1.0.2",
+    "prettier": "^1.17.0"
+  },
+  "engines": {
+    "node": "8.15.0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@quarterto"
+    ]
+  },
+  "prettier": "@quarterto/prettier",
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*": [
+      "precise-commits",
+      "git add"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mkdirp": "^0.5.1",
     "mz": "^2.7.0",
     "parse-github-url": "^1.0.2",
+    "rmfr": "^2.0.0",
     "tiny-relative-date": "^1.3.0",
     "yargs": "^13.2.2"
   },

--- a/src/commands/file.js
+++ b/src/commands/file.js
@@ -25,3 +25,7 @@ exports.handler = async ({ file }, state) => {
 		return { owner, name };
 	}).filter(Boolean);
 };
+
+exports.undo = (_, state) => {
+	delete state.repos;
+}

--- a/src/commands/file.js
+++ b/src/commands/file.js
@@ -15,12 +15,13 @@ exports.args = [{
 	) || 'Please enter a path to a text file containing a line-separated list of repositories'
 }];
 
-exports.handler = async ({file}) => {
+exports.handler = async ({ file }, state) => {
 	const contents = await fs.readFile(file, 'utf8');
-	return contents.split('\n').map(line => {
-		if(!line) return;
+
+	state.repos = contents.split('\n').map(line => {
+		if (!line) return;
 
 		const [owner, name] = line.split('/');
-		return {owner, name};
+		return { owner, name };
 	}).filter(Boolean);
 };

--- a/src/commands/filter-repo-name.js
+++ b/src/commands/filter-repo-name.js
@@ -9,4 +9,8 @@ exports.args = [{
 	type: 'text'
 }];
 
-exports.handler = ({filter, repos}) => repos.filter(repo => repo.name.match(new RegExp(filter)));
+exports.handler = ({ filter }, state) => {
+	state.repos = state.repos.filter(
+		repo => repo.name.match(new RegExp(filter))
+	);
+};

--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -50,7 +50,11 @@ exports.handler = async ({ projectData, githubAccessToken }, state) => {
 	state.project = project;
 };
 
-exports.undo = ({ project, githubAccessToken }) => getOctokit(githubAccessToken).projects.update({
-	project_id: project.id,
-	state: 'closed'
-});
+exports.undo = async ({ githubAccessToken }, state) => {
+	await getOctokit(githubAccessToken).projects.update({
+		project_id: state.project.id,
+		state: 'closed'
+	});
+
+	delete state.project;
+}

--- a/src/commands/prs.js
+++ b/src/commands/prs.js
@@ -37,23 +37,26 @@ exports.handler = async ({ templates: { title, body }, githubAccessToken }, stat
 				body: bodyTemplate(repo)
 			}).then(response => response.data);
 		}
-	}));
+	}))
 };
 
-exports.undo = ({ prs, githubAccessToken }) => (
-	Promise.all(prs.map(async pr => {
+
+exports.undo = ({ githubAccessToken }, state) => (
+	Promise.all(state.repos.map(async repo => {
 		await octokit(githubAccessToken).issues.createComment({
-			owner: pr.head.repo.owner.login,
-			repo: pr.head.repo.name,
-			number: pr.number,
+			owner: repo.pr.head.repo.owner.login,
+			repo: repo.pr.head.repo.name,
+			number: repo.pr.number,
 			body: 'automatically closed 🤖' //TODO prompt for template?
 		});
 
 		await octokit(githubAccessToken).pulls.update({
-			owner: pr.head.repo.owner.login,
-			repo: pr.head.repo.name,
-			number: pr.number,
+			owner: repo.pr.head.repo.owner.login,
+			repo: repo.pr.head.repo.name,
+			number: repo.pr.number,
 			state: 'closed'
 		});
+
+		delete repo.pr;
 	}))
 );

--- a/src/commands/run-script.js
+++ b/src/commands/run-script.js
@@ -44,7 +44,9 @@ exports.handler = async ({ script, branch }, state) => {
 	console.warn(`-- Script: ${scriptPath}`);
 	console.warn(`-- Target(s):\n\n   ${state.repos.map(({ name }) => name).join('\n   ')}`);
 
-	await Promise.all(state.repos.map(async repository => {
+	// must be serial until https://github.com/Financial-Times/tooling-helpers/issues/74
+	// is resolved (or, add workingDirectory to all the options of the git methods)
+	for (const repository of state.repos) {
 		console.warn('\n===\n');
 
 		const cloneDirectory = path.join(workspacePath, repository.name);
@@ -97,7 +99,7 @@ exports.handler = async ({ script, branch }, state) => {
 			console.warn(new Error(`Error running script for '${repository.name}': ${error.message}`));
 			throw error;
 		}
-	}));
+	}
 };
 
 exports.undo = ({ branch }, state) => {

--- a/src/commands/tako.js
+++ b/src/commands/tako.js
@@ -22,3 +22,7 @@ exports.handler = async ({ takoHost, takoToken, topic }, state) => {
 		({ body }) => body.repositories
 	);
 };
+
+exports.undo = (_, state) => {
+	delete state.repos;
+}

--- a/src/commands/tako.js
+++ b/src/commands/tako.js
@@ -11,12 +11,14 @@ exports.args = [{
 	message: '(optional) GitHub topic to filter by'
 }];
 
-exports.handler = ({takoHost, takoToken, topic}) => got(`https://${takoHost}/tako/repositories`, {
-	json: true,
-	headers: takoToken && {
-		authorization: `Bearer ${takoToken}`
-	},
-	query: {topic}
-}).then(
-	({body}) => body.repositories
-);
+exports.handler = async ({ takoHost, takoToken, topic }, state) => {
+	state.repos = await got(`https://${takoHost}/tako/repositories`, {
+		json: true,
+		headers: takoToken && {
+			authorization: `Bearer ${takoToken}`
+		},
+		query: { topic }
+	}).then(
+		({ body }) => body.repositories
+	);
+};

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -161,7 +161,7 @@ exports.handler = async function ({ state, ...argv }) {
 			}
 			console.log(c.gray('─────')); // eslint-disable-line no-console
 		} else if (choice === 'undo') {
-			await state.undo();
+			await state.undo(argv);
 		} else if (choice === 'done') {
 			break;
 		}

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -112,9 +112,7 @@ const promptOperation = ({ state }) => prompt({
 	name: 'choice',
 	message: 'available operations',
 	type: 'select',
-	header: Object.keys(state.state.data).map(
-		type => types[type].shortPreview(state.state.data[type])
-	).filter(Boolean).join(' ∙ '),
+	header: state.shortPreview(),
 	choices: Object.values(operations).map(operation => ({
 		name: operation.command,
 		message: operation.desc,

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -151,10 +151,13 @@ exports.handler = async function ({ state, ...argv }) {
 
 			await state.runStep(operation, args);
 		} else if (choice === 'preview') {
-			for (const type in state.state.data) if (state.state.data.hasOwnProperty(type)) {
+			for (const step of state.state.steps) {
+				const type = operations[step.name].output;
 				console.log(`${c.gray('─────')} ${type}`); // eslint-disable-line no-console
 				console.log( // eslint-disable-line no-console
-					types[type].format(state.state.data[type])
+					types[type].format(
+						types[type].getFromState(state.state.data)
+					)
 				);
 			}
 			console.log(c.gray('─────')); // eslint-disable-line no-console

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,7 +1,7 @@
 const fs = require('mz/fs');
-const {workspacePath} = require('./constants');
+const { workspacePath } = require('./constants');
 const path = require('path');
-const {prompt} = require('enquirer');
+const { prompt } = require('enquirer');
 const toSentence = require('./to-sentence');
 const util = require('util');
 const mkdirp = util.promisify(require('mkdirp'));
@@ -10,7 +10,7 @@ const configVars = [{
 	name: 'githubAccessToken',
 	message: 'Github access token (https://github.com/settings/tokens/new?scopes=repo&description=Nori)',
 	type: 'password'
-},{
+}, {
 	name: 'takoHost',
 	message: 'Tako hostname',
 	type: 'text',
@@ -41,14 +41,14 @@ module.exports = async function getConfig() {
 
 	try {
 		config = await readConfig();
-	} catch(_) {}
+	} catch (_) { }
 
 	const missingVars = configVars.filter(
 		configVar => !(configVar.name in config)
 	);
 
-	if(missingVars.length) {
-		if(process.stdin.isTTY) {
+	if (missingVars.length) {
+		if (process.stdin.isTTY) {
 			const promptConfig = await prompt(configVars);
 			Object.assign(config, promptConfig);
 			await writeConfig(config);

--- a/src/lib/operation-to-yargs-command.js
+++ b/src/lib/operation-to-yargs-command.js
@@ -45,7 +45,7 @@ const enquirerValidate = arg => async argv => {
 };
 
 const promptMissingArgs = operation => async argv => {
-	if (!argv.state.isValidOperation(operation)) {
+	if (argv.state.fileName && !argv.state.isValidOperation(operation)) {
 		const validCommands = Object.keys(operations).filter(key => argv.state.isValidOperation(operations[key]));
 		const message = `'${operation.command}' isn't valid for the provided state. ${validCommands.length ? `Valid commands are ${toSentence(validCommands.map(cmd => `'${cmd}'`))}` : ''}`;
 		throw new Error(message);
@@ -92,6 +92,13 @@ const operationToYargsCommand = operation => Object.assign({}, operation, {
 	},
 
 	handler({ state, ...args }) {
+		const stateArgs = {};
+		operation.input.forEach(type => {
+			stateArgs[type] = args[type];
+			delete args[type];
+		});
+
+		state.addData(stateArgs);
 		return state.runSingleOperation(operation, args);
 	}
 });

--- a/src/lib/operation-to-yargs-command.js
+++ b/src/lib/operation-to-yargs-command.js
@@ -3,12 +3,11 @@ const types = require('./types');
 const toSentence = require('./to-sentence');
 const operations = require('../operations');
 
-function enquirerToYargs(arg) {
+const enquirerToYargs = yargs => arg => {
 	const option = {
 		// alias: arg.name[0], how can we make sure this is unique?
 		describe: arg.message,
-		coerce: arg.result,
-	}
+	};
 
 	switch (arg.type) {
 		case 'text': {
@@ -30,33 +29,59 @@ function enquirerToYargs(arg) {
 		}
 	}
 
-	return option;
-}
+	yargs.option(arg.name, option)
 
-const enquirerValidate = arg => async argv => {
-	if (arg.validate) {
-		const maybeMessage = await arg.validate(argv[arg.name]);
-		if (typeof maybeMessage === 'string') {
-			throw new Error(maybeMessage);
-		}
+	if (arg.result) {
+		// we could use `yargs.coerce` here if we didn't have to support
+		// async functions like enquirer's `result`
+		yargs.middleware(async argv => ({
+			[arg.name]: await arg.result(argv[arg.name]),
+		}));
 	}
 
-	return {};
+	if (arg.validate) {
+		yargs.middleware(async argv => {
+			const maybeMessage = await arg.validate(argv[arg.name]);
+
+			// if an enquirer `validate` function returns a string,
+			// that's an error to throw. so throw it
+			if (typeof maybeMessage === 'string') {
+				throw new Error(maybeMessage);
+			}
+
+			return {};
+		});
+	}
+
+	return yargs;
+}
+
+const errorOnInvalidOperation = operation => argv => {
+	if (argv.state.fileName && !argv.state.isValidOperation(operation)) {
+		const validCommands = Object.keys(operations).filter(
+			key => argv.state.isValidOperation(operations[key])
+		);
+
+		const validMessage = validCommands.length ? `Valid commands are ${toSentence(validCommands.map(cmd => `'${cmd}'`))}` : '';
+		const message = `'${operation.command}' isn't valid for the provided state. ${validMessage}`;
+
+		throw new Error(message);
+	}
+};
+
+const checkMissingState = operation => async argv => {
+	const missingState = operation.input
+		.map(name => ({ ...types[name], name }))
+		.filter(type => !type.exists( // check if this type is in the state we have
+			type.getFromState(argv.state.state.data)
+		));
+
+
+	return { missingState };
 };
 
 const promptMissingArgs = operation => async argv => {
-	if (argv.state.fileName && !argv.state.isValidOperation(operation)) {
-		const validCommands = Object.keys(operations).filter(key => argv.state.isValidOperation(operations[key]));
-		const message = `'${operation.command}' isn't valid for the provided state. ${validCommands.length ? `Valid commands are ${toSentence(validCommands.map(cmd => `'${cmd}'`))}` : ''}`;
-		throw new Error(message);
-	}
-
-	const argsFromInputTypes = operation.input.map(
-		type => Object.assign({ name: type }, types[type].argument)
-	);
-
-	const allArgs = operation.args.concat(argsFromInputTypes);
-	const missingArgs = allArgs.filter(
+	const missingArgs = operation.args.filter(
 		arg => !(arg.name in argv)
 	);
 
@@ -64,43 +89,47 @@ const promptMissingArgs = operation => async argv => {
 		if (process.stdin.isTTY) {
 			return await prompt(missingArgs);
 		} else {
-			throw new Error(`Command '${operation.command}' requires arguments ${toSentence(missingArgs.map(arg => `'${arg.name}'`))}`);
+			return { missingArgs };
 		}
 	}
 
 	return {};
 };
 
+const errorOnMissing = operation => argv => {
+	let messages = [
+		argv.missingArgs && argv.missingArgs.length && (
+			`arguments ${toSentence(argv.missingArgs.map(arg => `'${arg.name}'`))}`
+		),
+		argv.missingState && argv.missingState.length && (
+			`state ${toSentence(argv.missingState.map(arg => `'${arg.name}'`))}`
+		),
+	].filter(Boolean);
+
+	if (messages.length) {
+		throw new Error(`Command '${operation.command}' requires ${toSentence(messages)}`);
+	}
+
+	return {};
+}
+
 const operationToYargsCommand = operation => Object.assign({}, operation, {
 	builder(yargs) {
 		if (operation.input) {
-			operation.input.forEach(type => yargs
-				.option(type, enquirerToYargs(types[type].argument))
-			);
+			yargs
+				.middleware(errorOnInvalidOperation(operation))
+				.middleware(checkMissingState(operation));
 		}
 
 		if (operation.args) {
-			operation.args.forEach(arg => yargs
-				.option(arg.name, enquirerToYargs(arg))
-				.middleware(enquirerValidate(arg))
-			);
-
+			operation.args.forEach(enquirerToYargs(yargs));
 			yargs.middleware(promptMissingArgs(operation));
 		}
 
-		return yargs;
+		return yargs.middleware(errorOnMissing(operation))
 	},
 
-	handler({ state, ...args }) {
-		const stateArgs = {};
-		operation.input.forEach(type => {
-			stateArgs[type] = args[type];
-			delete args[type];
-		});
-
-		state.addData(stateArgs);
-		return state.runSingleOperation(operation, args);
-	}
+	handler: ({ state, ...args }) => state.runSingleOperation(operation, args),
 });
 
 module.exports = operationToYargsCommand;

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -185,7 +185,7 @@ module.exports = class State {
 		);
 
 		this.state.data = await produce(this.state.data, async draft => {
-			for (const step of stepsToUndo) {
+			for (const step of stepsToUndo.slice().reverse()) {
 				const operation = operations[step.name];
 				if (operation.undo) {
 					await operation.undo(

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -198,7 +198,8 @@ module.exports = class State {
 
 		await this.save();
 
-		for (const step of stepsToUndo) {
+		// replay all but the last undone step
+		for (const step of stepsToUndo.slice(0, -1)) {
 			await this.runStep(
 				operations[step.name],
 				step.args,

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -215,4 +215,18 @@ module.exports = class State {
 			)
 			: operation.input.length === 0;
 	}
+
+	shortPreview() {
+		const stepOutputs = [...new Set(
+			this.state.steps.map(
+				step => operations[step.name].output
+			)
+		)]
+
+		const outputPreviews = stepOutputs.map(
+			type => types[type].shortPreview(this.state.data)
+		).filter(Boolean)
+
+		return outputPreviews.join(' ∙ ')
+	}
 }

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -89,10 +89,7 @@ module.exports = class State {
 
 		await stateContainer.load();
 
-		return {
-			state: stateContainer,
-			...stateContainer.state.data
-		};
+		return { state: stateContainer };
 	}
 
 	static async getSortedFiles() {
@@ -150,6 +147,10 @@ module.exports = class State {
 		}
 
 		return serialised;
+	}
+
+	addData(data) {
+		Object.assign(this.state.data, data);
 	}
 
 	async runSingleOperation(operation, args) {

--- a/src/lib/state.js
+++ b/src/lib/state.js
@@ -210,12 +210,11 @@ module.exports = class State {
 	}
 
 	isValidOperation(operation) {
-		const lastStep = this.state.steps[this.state.steps.length - 1];
-		return lastStep
-			? operation.input.includes(
-				operations[lastStep.name].output
-			)
-			: operation.input.length === 0;
+		const previousOutputs = new Set(this.state.steps.map(
+			step => operations[step.name].output
+		));
+
+		return operation.input.every(type => previousOutputs.has(type));
 	}
 
 	shortPreview() {

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -1,53 +1,30 @@
 module.exports = {
 	repos: {
-		argument: {
-			type: 'list',
-			result: repos => repos.map(repo => {
-				const [match, owner, name] = repo.match(/(.+?)\/(.+?)(?:.git)?$/) || [false];
-				if (match) {
-					return { owner, name };
-				}
-
-				throw new Error(`${repo} is not a valid repository`);
-			})
-		},
-		serialise: state => JSON.stringify(state.repos, null, 2),
-		format: state => state.repos.map(repo => `https://github.com/${repo.owner}/${repo.name}`).join('\n'),
-		shortPreview: state => state.repos ? `${state.repos.length} repositor${state.repos.length > 1 ? 'ies' : 'y'}` : false,
+		getFromState: state => state.repos,
+		exists: repos => repos && repos.length > 0,
+		format: repos => repos.map(repo => `https://github.com/${repo.owner}/${repo.name}`).join('\n'),
+		shortPreview: repos => `${repos.length} repositor${repos.length > 1 ? 'ies' : 'y'}`,
 	},
 
 	branches: {
-		argument: { type: 'list' },
-		serialise: state => JSON.stringify(state.repos.filter(repo => repo.remoteBranch), null, 2),
-		format: state => state.repos.map(repo => repo.remoteBranch).filter(Boolean).join('\n'),
-		shortPreview: state => {
-			if (!state.repos) return false;
-
-			const reposWithBranch = state.repos.filter(repo => 'remoteBranch' in repo)
-			if (reposWithBranch.length === 0) return false;
-
-			return `${reposWithBranch.length} remote branch${reposWithBranch.length > 1 ? 'es' : ''}`;
-		}
+		getFromState: state => state.repos && state.repos.map(repo => repo.remoteBranch).filter(Boolean),
+		exists: branches => branches && branches.length > 0,
+		format: branches => branches.join('\n'),
+		shortPreview: branches => `${branches.length} remote branch${branches.length > 1 ? 'es' : ''}`,
 	},
 
 	prs: {
-		argument: { type: 'list' },
-		serialise: state => JSON.stringify(state.repos.filter(repo => repo.pr), null, 2),
-		format: state => state.repos.map(repo => repo.pr && repo.pr.html_url).filter(Boolean).join('\n'),
-		shortPreview: state => {
-			if (!state.repos) return false;
-
-			const reposWithPr = state.repos.filter(repo => 'pr' in repo)
-			if (reposWithPr.length === 0) return false;
-
-			return `${reposWithPr.length} pull request${reposWithPr.length > 1 ? 's' : ''}`;
-		}
+		getFromState: state => state.prs && state.prs.map(repo => repo.remoteBranch).filter(Boolean),
+		exists: prs => prs && prs.length
+			> 0,
+		format: prs => prs.map(pr => pr.html_url).join('\n'),
+		shortPreview: prs => `${prs.length} pull request${prs.length > 1 ? 's' : ''}`,
 	},
 
 	project: {
-		argument: { type: 'list' },
-		serialise: state => JSON.stringify(state.project, null, 2),
-		format: state => state.project.html_url,
-		shortPreview: state => state.project ? state.project.html_url : false,
+		getFromState: state => state.project,
+		exists: project => Boolean(project),
+		format: project => project.html_url,
+		shortPreview: project => project.html_url,
 	},
 };

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -11,12 +11,14 @@ module.exports = {
 				throw new Error(`${repo} is not a valid repository`);
 			})
 		},
+		serialise: state => JSON.stringify(state.repos, null, 2),
 		format: state => state.repos.map(repo => `https://github.com/${repo.owner}/${repo.name}`).join('\n'),
 		shortPreview: state => state.repos ? `${state.repos.length} repositor${state.repos.length > 1 ? 'ies' : 'y'}` : false,
 	},
 
 	branches: {
 		argument: { type: 'list' },
+		serialise: state => JSON.stringify(state.repos.filter(repo => repo.remoteBranch), null, 2),
 		format: state => state.repos.map(repo => repo.remoteBranch).filter(Boolean).join('\n'),
 		shortPreview: state => {
 			if (!state.repos) return false;
@@ -30,6 +32,7 @@ module.exports = {
 
 	prs: {
 		argument: { type: 'list' },
+		serialise: state => JSON.stringify(state.repos.filter(repo => repo.pr), null, 2),
 		format: state => state.repos.map(repo => repo.pr && repo.pr.html_url).filter(Boolean).join('\n'),
 		shortPreview: state => {
 			if (!state.repos) return false;
@@ -43,6 +46,7 @@ module.exports = {
 
 	project: {
 		argument: { type: 'list' },
+		serialise: state => JSON.stringify(state.project, null, 2),
 		format: state => state.project.html_url,
 		shortPreview: state => state.project ? state.project.html_url : false,
 	},

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -4,32 +4,46 @@ module.exports = {
 			type: 'list',
 			result: repos => repos.map(repo => {
 				const [match, owner, name] = repo.match(/(.+?)\/(.+?)(?:.git)?$/) || [false];
-				if(match) {
-					return {owner, name};
+				if (match) {
+					return { owner, name };
 				}
 
 				throw new Error(`${repo} is not a valid repository`);
 			})
 		},
-		format: repos => repos.map(repo => `https://github.com/${repo.owner}/${repo.name}`).join('\n'),
-		shortPreview: repos => repos ? `${repos.length} repositor${repos.length > 1 ? 'ies' : 'y'}` : false,
+		format: state => state.repos.map(repo => `https://github.com/${repo.owner}/${repo.name}`).join('\n'),
+		shortPreview: state => state.repos ? `${state.repos.length} repositor${state.repos.length > 1 ? 'ies' : 'y'}` : false,
 	},
 
 	branches: {
-		argument: {type: 'list'},
-		format: result => result.join('\n'),
-		shortPreview: branches => branches ? `${branches.length} branch${branches.length > 1 ? 'es' : ''}` : false,
+		argument: { type: 'list' },
+		format: state => state.repos.map(repo => repo.remoteBranch).filter(Boolean).join('\n'),
+		shortPreview: state => {
+			if (!state.repos) return false;
+
+			const reposWithBranch = state.repos.filter(repo => 'remoteBranch' in repo)
+			if (reposWithBranch.length === 0) return false;
+
+			return `${reposWithBranch.length} remote branch${reposWithBranch.length > 1 ? 'es' : ''}`;
+		}
 	},
 
 	prs: {
-		argument: {type: 'list'},
-		format: result => result.map(pr => pr.html_url).join('\n'),
-		shortPreview: prs => prs ? `${prs.length} pull request${prs.length > 1 ? 's' : ''}` : false,
+		argument: { type: 'list' },
+		format: state => state.repos.map(repo => repo.pr && repo.pr.html_url).filter(Boolean).join('\n'),
+		shortPreview: state => {
+			if (!state.repos) return false;
+
+			const reposWithPr = state.repos.filter(repo => 'pr' in repo)
+			if (reposWithPr.length === 0) return false;
+
+			return `${reposWithPr.length} pull request${reposWithPr.length > 1 ? 's' : ''}`;
+		}
 	},
 
 	project: {
-		argument: {type: 'list'},
-		format: result => result.html_url,
-		shortPreview: project => project ? project.html_url : false,
+		argument: { type: 'list' },
+		format: state => state.project.html_url,
+		shortPreview: state => state.project ? state.project.html_url : false,
 	},
 };

--- a/test/commands/file.test.js
+++ b/test/commands/file.test.js
@@ -23,7 +23,7 @@ test('`file` command module exports an operation object', () => {
 
 test('`file` command correctly throws an error if the file does not exist', async () => {
 	vol.fromJSON({});
-	await expect(file.handler({ file: 'non-existent.txt' }))
+	await expect(file.handler({ file: 'non-existent.txt' }, {}))
 		.rejects
 		.toThrow('ENOENT: no such file or directory')
 })
@@ -33,11 +33,12 @@ test('`file` command returns the correct data', async () => {
 		'repositories.txt': 'owner/repo'
 	});
 
-	await expect(file.handler({ file: 'repositories.txt' }))
-		.resolves
-		.toEqual(
-			[{ owner: 'owner', name: 'repo' }]
-		);
+	const state = {}
+	await file.handler({ file: 'repositories.txt' }, state)
+
+	expect(state.repos).toEqual(
+		[{ owner: 'owner', name: 'repo' }]
+	);
 });
 
 test.todo('`file` command correctly throws an error if the file contents are in an incorrect format');

--- a/test/commands/file.test.js
+++ b/test/commands/file.test.js
@@ -42,3 +42,13 @@ test('`file` command returns the correct data', async () => {
 });
 
 test.todo('`file` command correctly throws an error if the file contents are in an incorrect format');
+
+test('`file` undo removes repos from state', () => {
+	const state = {
+		repos: [{ owner: 'owner', name: 'repo' }]
+	};
+
+	file.undo({}, state);
+
+	expect(state).toEqual({});
+});

--- a/test/commands/project.test.js
+++ b/test/commands/project.test.js
@@ -77,13 +77,17 @@ describe('creating project board', () => {
 	});
 });
 
-test('undo closes the project', async () => {
-	await project.undo({ githubAccessToken }, {
+test('undo closes the project and removes data from state', async () => {
+	const state = {
 		project: { id: 'mock project id' },
-	});
+	};
+
+	await project.undo({ githubAccessToken }, state);
 
 	expect(octokit.projects.update).toHaveBeenCalledWith({
 		project_id: 'mock project id',
 		state: 'closed'
 	});
+
+	expect(state).toEqual({});
 });

--- a/test/commands/project.test.js
+++ b/test/commands/project.test.js
@@ -25,13 +25,14 @@ describe('creating project board', () => {
 
 	beforeAll(() => project.handler({
 		projectData,
-		prs: [
-			{id: 'pull request 1'},
-			{id: 'pull request 2'},
-			{id: 'pull request 3'},
-		],
 		githubAccessToken
-	}));
+	}, {
+			repos: [
+				{ pr: { id: 'pull request 1' } },
+				{ pr: { id: 'pull request 2' } },
+				{ pr: { id: 'pull request 3' } },
+			],
+		}));
 
 	test('creates the project board', () => {
 		expect(octokit.projects.createForOrg).toHaveBeenCalledWith(projectData);
@@ -78,7 +79,7 @@ describe('creating project board', () => {
 
 test('undo closes the project', async () => {
 	await project.undo({
-		project: {id: 'mock project id'},
+		project: { id: 'mock project id' },
 		githubAccessToken,
 	});
 

--- a/test/commands/project.test.js
+++ b/test/commands/project.test.js
@@ -78,9 +78,8 @@ describe('creating project board', () => {
 });
 
 test('undo closes the project', async () => {
-	await project.undo({
+	await project.undo({ githubAccessToken }, {
 		project: { id: 'mock project id' },
-		githubAccessToken,
 	});
 
 	expect(octokit.projects.update).toHaveBeenCalledWith({

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -25,16 +25,14 @@ describe('creating pull requests', () => {
 				title: 'pull request title ${repo.name}',
 				body: 'pull request body ${repo.name}'
 			},
-			repos: [
-				{owner: 'org', name: 'repo1'},
-				{owner: 'org', name: 'repo2'},
-			],
-			branches: [
-				'branch1',
-				'branch2',
-			],
 			githubAccessToken
-		})
+		}, {
+				repos: [
+					{ owner: 'org', name: 'repo1', remoteBranch: 'branch1' },
+					{ owner: 'org', name: 'repo2', remoteBranch: 'branch2' },
+				],
+			}
+		)
 
 		expect(octokit.pulls.create).toHaveBeenCalledWith({
 			owner: 'org', repo: 'repo1', head: 'branch1', base: 'master',
@@ -55,22 +53,21 @@ describe('creating pull requests', () => {
 				title: 'pull request title ` ',
 				body: 'pull request body'
 			},
-			repos: [
-				{owner: 'org', name: 'repo1'},
-			],
-			branches: [
-				'branch1',
-			],
 			githubAccessToken
-		})).resolves.not.toThrow()
+		}, {
+				repos: [
+					{ owner: 'org', name: 'repo1', remoteBranch: 'branch1' },
+				],
+			}
+		)).resolves.not.toThrow()
 	});
 });
 
 describe('undoing pull requests', () => {
 	beforeAll(() => prs.undo({
 		prs: [
-			{head: {repo: {owner: {login: 'org'}, name: 'repo1'}}, number: 1},
-			{head: {repo: {owner: {login: 'org'}, name: 'repo2'}}, number: 2},
+			{ head: { repo: { owner: { login: 'org' }, name: 'repo1' } }, number: 1 },
+			{ head: { repo: { owner: { login: 'org' }, name: 'repo2' } }, number: 2 },
 		],
 		githubAccessToken
 	}));

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -64,12 +64,11 @@ describe('creating pull requests', () => {
 });
 
 describe('undoing pull requests', () => {
-	beforeAll(() => prs.undo({
-		prs: [
-			{ head: { repo: { owner: { login: 'org' }, name: 'repo1' } }, number: 1 },
-			{ head: { repo: { owner: { login: 'org' }, name: 'repo2' } }, number: 2 },
-		],
-		githubAccessToken
+	beforeAll(() => prs.undo({ githubAccessToken }, {
+		repos: [
+			{ pr: { head: { repo: { owner: { login: 'org' }, name: 'repo1' } }, number: 1 } },
+			{ pr: { head: { repo: { owner: { login: 'org' }, name: 'repo2' } }, number: 2 } },
+		]
 	}));
 
 	test('comments on every PR', () => {

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -48,28 +48,31 @@ describe('creating pull requests', () => {
 	});
 
 	test('doesn\'t error on backticks in string', () => {
-		expect(prs.handler({
-			templates: {
-				title: 'pull request title ` ',
-				body: 'pull request body'
-			},
-			githubAccessToken
-		}, {
-				repos: [
-					{ owner: 'org', name: 'repo1', remoteBranch: 'branch1' },
-				],
-			}
-		)).resolves.not.toThrow()
+		expect(prs.handler
+			({
+				templates: {
+					title: 'pull request title ` ',
+					body: 'pull request body'
+				},
+				githubAccessToken
+			}, {
+					repos: [
+						{ owner: 'org', name: 'repo1', remoteBranch: 'branch1' },
+					],
+				}
+			)).resolves.not.toThrow()
 	});
 });
 
 describe('undoing pull requests', () => {
-	beforeAll(() => prs.undo({ githubAccessToken }, {
+	const state = {
 		repos: [
 			{ pr: { head: { repo: { owner: { login: 'org' }, name: 'repo1' } }, number: 1 } },
 			{ pr: { head: { repo: { owner: { login: 'org' }, name: 'repo2' } }, number: 2 } },
 		]
-	}));
+	};
+
+	beforeAll(() => prs.undo({ githubAccessToken }, state));
 
 	test('comments on every PR', () => {
 		expect(octokit.issues.createComment).toHaveBeenCalledWith({
@@ -93,5 +96,11 @@ describe('undoing pull requests', () => {
 			owner: 'org', repo: 'repo2', number: 2,
 			state: 'closed'
 		});
+	});
+
+	test('removes PR data from state', () => {
+		expect(state).toEqual({
+			repos: [{}, {}]
+		})
 	});
 });

--- a/test/commands/run-script.test.js
+++ b/test/commands/run-script.test.js
@@ -29,7 +29,7 @@ test('`run-script` command module exports an operation object', () => {
 
 test('errors when `repos` is an empty array', async () => {
 	await expect(
-		runScript.handler({
+		runScript.handler({}, {
 			repos: []
 		})
 	).rejects.toThrowError(/no repos specified/i);
@@ -41,8 +41,9 @@ test('errors when `script` is empty', async () => {
 	});
 	await expect(
 		runScript.handler({
-			repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 			workspace: 'hello'
+		}, {
+			repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 		})
 	).rejects.toThrowError(/undefined/i);
 });
@@ -53,9 +54,10 @@ test('errors when `script` does not exist', async () => {
 	});
 	await expect(
 		runScript.handler({
-			repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 			workspace: 'hello',
 			script: 'somefile.js'
+		}, {
+			repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 		})
 	).rejects.toThrowError(/script does not exist/i);
 });
@@ -75,9 +77,10 @@ test('errors when `script` is not executable', async () => {
 
 	await expect(
 		runScript.handler({
-			repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 			workspace: 'hello',
 			script: 'transformation.js'
+		}, {
+			repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 		})
 	).rejects.toThrowError(/script is not executable/i);
 });
@@ -91,9 +94,10 @@ test('runs script', async () => {
 	fs.access.mockImplementation(util.callbackify(async () => undefined));
 
 	await runScript.handler({
-		repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 		workspace: 'hello',
 		script: 'transformation.js'
+	}, {
+		repos: [{ owner: 'Financial-Times', name: 'next-search-page' }],
 	});
 
 	expect(runProcess).toBeCalledWith(path.resolve('transformation.js'), expect.any(Object));

--- a/test/commands/run-script.test.js
+++ b/test/commands/run-script.test.js
@@ -102,3 +102,4 @@ test('runs script', async () => {
 
 	expect(runProcess).toBeCalledWith(path.resolve('transformation.js'), expect.any(Object));
 });
+

--- a/test/commands/tako.test.js
+++ b/test/commands/tako.test.js
@@ -3,7 +3,7 @@ const expectOperation = require('../../test-utils/operation');
 const got = require('got');
 
 jest.mock('got', () => jest.fn(
-	() => Promise.resolve({body: {repositories: [{owner: 'owner', name: 'name'}]}})
+	() => Promise.resolve({ body: { repositories: [{ owner: 'owner', name: 'name' }] } })
 ));
 
 test('`tako` command module exports an operation object', () => {
@@ -25,12 +25,14 @@ test('calls the tako host you give it with the token and topic you give it', () 
 		headers: {
 			authorization: `Bearer ${takoToken}`
 		},
-		query: {topic}
+		query: { topic }
 	}));
 });
 
 test('returns the repositories from tako', async () => {
-	await expect(tako.handler({})).resolves.toEqual(
+	const state = {}
+	await tako.handler({}, state);
+	expect(state.repos).toEqual(
 		expect.arrayContaining([
 			expect.objectContaining({
 				owner: 'owner',

--- a/test/commands/tako.test.js
+++ b/test/commands/tako.test.js
@@ -41,3 +41,13 @@ test('returns the repositories from tako', async () => {
 		])
 	);
 });
+
+test('`tako` undo removes repos from state', () => {
+	const state = {
+		repos: [{ owner: 'owner', name: 'repo' }]
+	};
+
+	tako.undo({}, state);
+
+	expect(state).toEqual({});
+});


### PR DESCRIPTION
this is to fix #60.

previously, each operation was given a slice of the state data (its `input` types) and expected to return an object to store at another place in the state data (its `output` type). for example, the `prs` operation has `input` of `['repos', 'branches']`, because it need information about the Github origin to create the PR on (e.g. created by the `file` operation), and the branch for the `HEAD` of the PR (e.g. created by the `run-script` operation).

this worked great, but it's limiting. because there's no link between each step's data, there's no way of knowing e.g. which branch or PR pertains to which repo, apart from by its position in the array, which makes it impossible to do incremental operations, e.g. only creating PRs for branches that have changes (see #26).

this new model makes the input and output types abstract, not directly linked to the state data, and only used for filtering which operations are available after running/choosing each step. operations then become responsible for updating the state in whatever way they see fit (such as setting items on only the relevant items in an array e.g. only setting `repos[137].pr` if `repos[137].remoteBranch` exists). 