### PR TITLE
PR entry returns true if title provided

### DIFF
--- a/src/commands/prs.js
+++ b/src/commands/prs.js
@@ -18,6 +18,7 @@ exports.args = [{
 		if(!templates.title) {
 			return 'Please provide a Pull Request title';
 		}
+		return true
 	}
 }];
 

--- a/src/lib/octokit.js
+++ b/src/lib/octokit.js
@@ -15,7 +15,8 @@ module.exports = token => {
 					if (options.request.retryCount === 0) {
 						return true;
 					}
-				}
+				},
+				onAbuseLimit: () => {},
 			}
 		});
 	}

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -15,7 +15,7 @@ test('correctly throws an error if given incorrect arguments', () => {
 	const templatesArg = prs.args.find(arg => arg.name === 'templates');
 
 	expect(templatesArg.validate({})).toBe('Please provide a Pull Request title');
-	expect(templatesArg.validate({ title: 'foo' })).toBeUndefined();
+	expect(templatesArg.validate({ title: 'foo' })).toBeTruthy();
 });
 
 describe('creating pull requests', () => {


### PR DESCRIPTION
Fixes #78.  If a title for a PR is provided, then we want to return true so that enquirer doesnt kick up a fuss and we can run nori on 70 repos thanks.