### PR TITLE
Validate project name properly

### DIFF
--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -24,6 +24,7 @@ exports.args = [{
 		if (messages.length) {
 			return `Please provide ${toSentence(messages)}`;
 		}
+		return true
 	}
 }];
 

--- a/test/commands/project.test.js
+++ b/test/commands/project.test.js
@@ -17,7 +17,7 @@ test('correctly throws an error if given incorrect arguments', () => {
 	expect(projectDataArg.validate({})).toBe('Please provide a project name and a GitHub organisation to create the project in');
 	expect(projectDataArg.validate({ name: 'foo' })).toBe('Please provide a GitHub organisation to create the project in');
 	expect(projectDataArg.validate({ org: 'foo' })).toBe('Please provide a project name');
-	expect(projectDataArg.validate({ name: 'foo', org: 'foo' })).toBeUndefined();
+	expect(projectDataArg.validate({ name: 'foo', org: 'foo' })).toBeTruthy();
 });
 
 describe('creating project board', () => {


### PR DESCRIPTION
This validation needs to return true so that there is no `invalid input` error when nori is creating a Github Project for PRs.