### PR TITLE
Add PR body validation

### DIFF
--- a/src/commands/prs.js
+++ b/src/commands/prs.js
@@ -1,4 +1,5 @@
 const octokit = require('../lib/octokit')
+const toSentence = require('../lib/to-sentence')
 
 exports.command = 'prs'
 exports.desc = 'create Github pull requests for pushed branches'
@@ -13,8 +14,14 @@ exports.args = [
 		message: 'Pull Request details',
 		choices: [{ name: 'title' }, { name: 'body' }],
 		validate: templates => {
-			if (!templates.title) {
-				return 'Please provide a Pull Request title'
+			const { title, body } = templates
+			const messages = [
+				!title && 'a Pull Request title',
+				!body && 'a Pull Request body',
+			].filter(Boolean)
+
+			if (messages.length) {
+				return `Please provide ${toSentence(messages)}`
 			}
 			return true
 		},

--- a/test/commands/project.test.js
+++ b/test/commands/project.test.js
@@ -17,7 +17,7 @@ test('correctly throws an error if given incorrect arguments', () => {
 	expect(projectDataArg.validate({})).toBe('Please provide a project name and a GitHub organisation to create the project in');
 	expect(projectDataArg.validate({ name: 'foo' })).toBe('Please provide a GitHub organisation to create the project in');
 	expect(projectDataArg.validate({ org: 'foo' })).toBe('Please provide a project name');
-	expect(projectDataArg.validate({ name: 'foo', org: 'foo' })).toBeTruthy();
+	expect(projectDataArg.validate({ name: 'foo', org: 'foo' })).toEqual(true);
 });
 
 describe('creating project board', () => {

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -14,8 +14,9 @@ test('`prs` command module exports an operation object', () => {
 test('correctly throws an error if given incorrect arguments', () => {
 	const templatesArg = prs.args.find(arg => arg.name === 'templates');
 
-	expect(templatesArg.validate({})).toBe('Please provide a Pull Request title');
-	expect(templatesArg.validate({ title: 'foo' })).toEqual(true);
+	expect(templatesArg.validate({})).toBe('Please provide a Pull Request title and a Pull Request body');
+	expect(templatesArg.validate({ title: 'foo' })).toBe('Please provide a Pull Request body');
+	expect(templatesArg.validate({ title: 'foo', body: 'bar body' })).toEqual(true);
 });
 
 describe('creating pull requests', () => {

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -15,7 +15,7 @@ test('correctly throws an error if given incorrect arguments', () => {
 	const templatesArg = prs.args.find(arg => arg.name === 'templates');
 
 	expect(templatesArg.validate({})).toBe('Please provide a Pull Request title');
-	expect(templatesArg.validate({ title: 'foo' })).toBeTruthy();
+	expect(templatesArg.validate({ title: 'foo' })).toEqual(true);
 });
 
 describe('creating pull requests', () => {


### PR DESCRIPTION
Helps with https://github.com/Financial-Times/nori/issues/89, as it prevents PRs being generated when the PR body is empty. For most cases, we'll probably want a PR body anyway, considering we'd want to add some context to mass-created PRs.

Also updated the tests to be more explicit in catching validation errors (0efef80)