### PR TITLE
split creating and adding to projects; support existing projects

### DIFF
--- a/__mocks__/@octokit/rest.js
+++ b/__mocks__/@octokit/rest.js
@@ -16,7 +16,7 @@ module.exports = function Octokit() {
 				}),
 			),
 			createCard: jest.fn(),
-			updateCard: jest.fn(),
+			deleteCard: jest.fn(),
 			update: jest.fn(),
 		},
 		pulls: {

--- a/__mocks__/@octokit/rest.js
+++ b/__mocks__/@octokit/rest.js
@@ -1,36 +1,43 @@
 module.exports = function Octokit() {
 	return {
+		paginate: jest.fn().mockImplementation(async args => {
+			if (args === 'mock listForOrg.endpoint.merge data') {
+				return [{ number: 137, id: 'mock project id' }]
+			}
+		}),
 		projects: {
-			createForOrg: jest.fn().mockReturnValue(
-				Promise.resolve({
-					data: {
-						id: 'mock project id',
-					},
-				}),
-			),
-			createColumn: jest.fn().mockReturnValue(
-				Promise.resolve({
-					data: {
-						id: 'mock column id',
-					},
-				}),
-			),
-			createCard: jest.fn().mockReturnValue(
-				Promise.resolve({
-					data: {
-						id: 'mock card id',
-					},
-				}),
-			),
+			createForOrg: jest.fn().mockResolvedValue({
+				data: {
+					id: 'mock project id',
+				},
+			}),
+			createColumn: jest.fn().mockResolvedValue({
+				data: {
+					id: 'mock column id',
+				},
+			}),
+			createCard: jest.fn().mockResolvedValue({
+				data: {
+					id: 'mock card id',
+				},
+			}),
 			deleteCard: jest.fn(),
 			update: jest.fn(),
+			listForOrg: Object.assign(jest.fn(), {
+				endpoint: {
+					merge: jest
+						.fn()
+						.mockReturnValue('mock listForOrg.endpoint.merge data'),
+				},
+			}),
+			listColumns: jest
+				.fn()
+				.mockResolvedValue({ data: [{ id: 'mock column id' }] }),
 		},
 		pulls: {
-			create: jest.fn().mockReturnValue(
-				Promise.resolve({
-					data: { id: 'mock pr id' },
-				}),
-			),
+			create: jest.fn().mockResolvedValue({
+				data: { id: 'mock pr id' },
+			}),
 			update: jest.fn(),
 		},
 		issues: {

--- a/__mocks__/@octokit/rest.js
+++ b/__mocks__/@octokit/rest.js
@@ -15,7 +15,13 @@ module.exports = function Octokit() {
 					},
 				}),
 			),
-			createCard: jest.fn(),
+			createCard: jest.fn().mockReturnValue(
+				Promise.resolve({
+					data: {
+						id: 'mock card id',
+					},
+				}),
+			),
 			deleteCard: jest.fn(),
 			update: jest.fn(),
 		},

--- a/__mocks__/@octokit/rest.js
+++ b/__mocks__/@octokit/rest.js
@@ -1,30 +1,37 @@
 module.exports = function Octokit() {
 	return {
 		projects: {
-			createForOrg: jest.fn().mockReturnValue(Promise.resolve({
-				data: {
-					id: 'mock project id'
-				}
-			})),
-			createColumn: jest.fn().mockReturnValue(Promise.resolve({
-				data: {
-					id: 'mock column id'
-				}
-			})),
+			createForOrg: jest.fn().mockReturnValue(
+				Promise.resolve({
+					data: {
+						id: 'mock project id',
+					},
+				}),
+			),
+			createColumn: jest.fn().mockReturnValue(
+				Promise.resolve({
+					data: {
+						id: 'mock column id',
+					},
+				}),
+			),
 			createCard: jest.fn(),
+			updateCard: jest.fn(),
 			update: jest.fn(),
 		},
 		pulls: {
-			create: jest.fn().mockReturnValue(Promise.resolve({
-				data: { id: 'mock pr id' }
-			})),
-			update: jest.fn()
+			create: jest.fn().mockReturnValue(
+				Promise.resolve({
+					data: { id: 'mock pr id' },
+				}),
+			),
+			update: jest.fn(),
 		},
 		issues: {
-			createComment: jest.fn()
-		}
+			createComment: jest.fn(),
+		},
 	}
 }
 
 // Return the Octokit instance for calls to plugin.
-module.exports.plugin = () => module.exports;
+module.exports.plugin = () => module.exports

--- a/src/commands/add-to-project.js
+++ b/src/commands/add-to-project.js
@@ -7,7 +7,7 @@ exports.input = ['prs', 'project']
 exports.output = 'projectCards'
 exports.args = state => [
 	{
-		type: 'list',
+		type: 'select',
 		name: 'column',
 		message: 'Column to add cards to',
 		choices: state.project.columns.map(column => ({
@@ -23,11 +23,11 @@ exports.handler = async ({ column, githubAccessToken }, state) => {
 	await Promise.all(
 		state.repos.map(async repo => {
 			if (repo.pr) {
-				repo.card = await octokit.projects.createCard({
+				repo.card = (await octokit.projects.createCard({
 					column_id: column,
 					content_id: repo.pr.id,
 					content_type: 'PullRequest',
-				})
+				})).data
 			}
 		}),
 	)
@@ -38,9 +38,8 @@ exports.undo = async ({ githubAccessToken }, state) => {
 	await Promise.all(
 		state.repos.map(async repo => {
 			if (repo.card) {
-				octokit.projects.updateCard({
+				await octokit.projects.deleteCard({
 					card_id: repo.card.id,
-					archived: true,
 				})
 
 				delete repo.card

--- a/src/commands/add-to-project.js
+++ b/src/commands/add-to-project.js
@@ -1,0 +1,50 @@
+const getOctokit = require('../lib/octokit')
+
+exports.command = 'add-to-project'
+exports.desc = 'add pull requests to a Github project'
+
+exports.input = ['prs', 'project']
+exports.output = 'projectCards'
+exports.args = state => [
+	{
+		type: 'list',
+		name: 'column',
+		message: 'Column to add cards to',
+		choices: state.project.columns.map(column => ({
+			message: column.name,
+			name: column.id,
+		})),
+	},
+]
+
+exports.handler = async ({ column, githubAccessToken }, state) => {
+	const octokit = getOctokit(githubAccessToken)
+
+	await Promise.all(
+		state.repos.map(async repo => {
+			if (repo.pr) {
+				repo.card = await octokit.projects.createCard({
+					column_id: column,
+					content_id: repo.pr.id,
+					content_type: 'PullRequest',
+				})
+			}
+		}),
+	)
+}
+
+exports.undo = async ({ githubAccessToken }, state) => {
+	const octokit = getOctokit(githubAccessToken)
+	await Promise.all(
+		state.repos.map(async repo => {
+			if (repo.card) {
+				octokit.projects.updateCard({
+					card_id: repo.card.id,
+					archived: true,
+				})
+
+				delete repo.card
+			}
+		}),
+	)
+}

--- a/src/commands/create-project.js
+++ b/src/commands/create-project.js
@@ -45,7 +45,7 @@ exports.handler = async ({ projectData, githubAccessToken }, state) => {
 			project_id: project.id,
 			name: 'Done',
 		}),
-	]
+	].map(column => column.data)
 
 	state.project = project
 }

--- a/src/commands/create-project.js
+++ b/src/commands/create-project.js
@@ -1,11 +1,10 @@
 const getOctokit = require('../lib/octokit')
 const toSentence = require('../lib/to-sentence')
 
-exports.command = 'project'
-exports.desc =
-	'create a Github project board and attach the pull requests to it'
+exports.command = 'create-project'
+exports.desc = 'create a Github project board'
 
-exports.input = ['prs']
+exports.input = []
 exports.output = 'project'
 
 exports.args = [
@@ -31,27 +30,22 @@ exports.args = [
 exports.handler = async ({ projectData, githubAccessToken }, state) => {
 	const octokit = getOctokit(githubAccessToken)
 	const { data: project } = await octokit.projects.createForOrg(projectData)
-	const { data: todoColumn } = await octokit.projects.createColumn({
-		project_id: project.id,
-		name: 'To do',
-	})
-	await octokit.projects.createColumn({
-		project_id: project.id,
-		name: 'In progress',
-	})
-	await octokit.projects.createColumn({ project_id: project.id, name: 'Done' })
 
-	await Promise.all(
-		state.repos.map(repo => {
-			if (repo.pr) {
-				return octokit.projects.createCard({
-					column_id: todoColumn.id,
-					content_id: repo.pr.id,
-					content_type: 'PullRequest',
-				})
-			}
+	// do these in series so they're in the right order on the board
+	project.columns = [
+		await octokit.projects.createColumn({
+			project_id: project.id,
+			name: 'To do',
 		}),
-	)
+		await octokit.projects.createColumn({
+			project_id: project.id,
+			name: 'In progress',
+		}),
+		await octokit.projects.createColumn({
+			project_id: project.id,
+			name: 'Done',
+		}),
+	]
 
 	state.project = project
 }

--- a/src/commands/get-project.js
+++ b/src/commands/get-project.js
@@ -1,0 +1,54 @@
+const getOctokit = require('../lib/octokit')
+
+exports.command = 'get-project'
+exports.desc = 'get a Github project board'
+
+exports.input = []
+exports.output = 'project'
+
+const githubProjectURLRegex = /^https:\/\/github.com\/orgs\/([^\/]+)\/projects\/(\d+)$/
+
+exports.args = [
+	{
+		name: 'projectUrl',
+		message: 'GitHub organisation project URL',
+		type: 'text',
+		choices: [{ name: 'name' }, { name: 'org' }],
+		validate: url => {
+			if (url.match(githubProjectURLRegex)) {
+				return true
+			}
+
+			return 'Please enter a valid GitHub organisation project URL'
+		},
+	},
+]
+
+exports.handler = async ({ projectUrl, githubAccessToken }, state) => {
+	const [, org, number] = projectUrl.match(githubProjectURLRegex)
+
+	const octokit = getOctokit(githubAccessToken)
+
+	// shit me it needs to paginate
+	const { data: projects } = await octokit.projects.listForOrg({ org })
+	console.log(projects)
+	const project = projects.find(
+		project => project.number === parseInt(number, 10),
+	)
+
+	if (!project) {
+		throw new Error(
+			`There's no project #${number} in ${org}. Check https://github.com/orgs/${org}/projects/${number}`,
+		)
+	}
+
+	project.columns = (await octokit.projects.getColumns({
+		project_id: project.id,
+	})).data
+
+	state.project = project
+}
+
+exports.undo = async (args, state) => {
+	delete state.project
+}

--- a/src/commands/get-project.js
+++ b/src/commands/get-project.js
@@ -29,9 +29,9 @@ exports.handler = async ({ projectUrl, githubAccessToken }, state) => {
 
 	const octokit = getOctokit(githubAccessToken)
 
-	// shit me it needs to paginate
-	const { data: projects } = await octokit.projects.listForOrg({ org })
-	console.log(projects)
+	const projects = await octokit.paginate(
+		octokit.projects.listForOrg.endpoint.merge({ org }),
+	)
 	const project = projects.find(
 		project => project.number === parseInt(number, 10),
 	)
@@ -42,7 +42,7 @@ exports.handler = async ({ projectUrl, githubAccessToken }, state) => {
 		)
 	}
 
-	project.columns = (await octokit.projects.getColumns({
+	project.columns = (await octokit.projects.listColumns({
 		project_id: project.id,
 	})).data
 

--- a/src/commands/prs.js
+++ b/src/commands/prs.js
@@ -65,14 +65,14 @@ exports.undo = ({ githubAccessToken }, state) =>
 			await octokit(githubAccessToken).issues.createComment({
 				owner: repo.pr.head.repo.owner.login,
 				repo: repo.pr.head.repo.name,
-				number: repo.pr.number,
+				issue_number: repo.pr.number,
 				body: 'automatically closed 🤖', //TODO prompt for template?
 			})
 
 			await octokit(githubAccessToken).pulls.update({
 				owner: repo.pr.head.repo.owner.login,
 				repo: repo.pr.head.repo.name,
-				number: repo.pr.number,
+				pull_number: repo.pr.number,
 				state: 'closed',
 			})
 

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -156,7 +156,7 @@ exports.handler = async function({ state, ...argv }) {
 			const operation = operations[choice]
 			const promptArgs =
 				typeof operation.args === 'function'
-					? await operation.args(state)
+					? await operation.args(state.state.data)
 					: operation.args
 
 			const args = Object.assign({}, argv, await prompt(promptArgs))

--- a/src/interactive.js
+++ b/src/interactive.js
@@ -154,7 +154,12 @@ exports.handler = async function({ state, ...argv }) {
 
 		if (choice in operations) {
 			const operation = operations[choice]
-			const args = Object.assign({}, argv, await prompt(operation.args))
+			const promptArgs =
+				typeof operation.args === 'function'
+					? await operation.args(state)
+					: operation.args
+
+			const args = Object.assign({}, argv, await prompt(promptArgs))
 
 			await state.runStep(operation, args)
 		} else if (choice === 'preview') {

--- a/src/lib/types.js
+++ b/src/lib/types.js
@@ -56,4 +56,18 @@ module.exports = {
 		format: project => project.html_url,
 		shortPreview: project => project.html_url,
 	},
+
+	projectCards: {
+		getFromState: state =>
+			state.repos && state.repos.map(repo => repo.card).filter(Boolean),
+		exists: cards => cards && cards.length > 0,
+		format: cards =>
+			cards.map(
+				card =>
+					`${card.project_url.replace('api.github.com', 'github.com')}#card-${
+						card.id
+					}`,
+			),
+		shortPreview: cards => `${cards.length} card${cards.length > 1 ? 's' : ''}`,
+	},
 }

--- a/src/operations.js
+++ b/src/operations.js
@@ -6,6 +6,7 @@ module.exports = {
 	'run-script': require('./commands/run-script'),
 	'push-branches': require('./commands/push-branches'),
 	prs: require('./commands/prs'),
+	'get-project': require('./commands/get-project'),
 	'create-project': require('./commands/create-project'),
 	'add-to-project': require('./commands/add-to-project'),
 }

--- a/src/operations.js
+++ b/src/operations.js
@@ -6,5 +6,6 @@ module.exports = {
 	'run-script': require('./commands/run-script'),
 	'push-branches': require('./commands/push-branches'),
 	prs: require('./commands/prs'),
-	project: require('./commands/project'),
+	'create-project': require('./commands/create-project'),
+	'add-to-project': require('./commands/add-to-project'),
 }

--- a/test/commands/add-to-project.test.js
+++ b/test/commands/add-to-project.test.js
@@ -1,0 +1,67 @@
+const addToProject = require('../../src/commands/add-to-project')
+const getOctokit = require('../../src/lib/octokit')
+
+const githubAccessToken = 'mock access token'
+const octokit = getOctokit(githubAccessToken)
+
+describe('adding to project', () => {
+	beforeAll(() =>
+		addToProject.handler(
+			{
+				column: 1,
+				githubAccessToken,
+			},
+			{
+				project: {
+					columns: [{ id: 1, name: 'To do' }],
+				},
+				repos: [
+					{ pr: { id: 'pull request 1' } },
+					{ pr: { id: 'pull request 2' } },
+					{ pr: { id: 'pull request 3' } },
+				],
+			},
+		),
+	)
+
+	test('adds every Pull Request to the board', async () => {
+		expect(octokit.projects.createCard).toHaveBeenCalledWith({
+			column_id: 1,
+			content_id: 'pull request 1',
+			content_type: 'PullRequest',
+		})
+
+		expect(octokit.projects.createCard).toHaveBeenCalledWith({
+			column_id: 1,
+			content_id: 'pull request 2',
+			content_type: 'PullRequest',
+		})
+
+		expect(octokit.projects.createCard).toHaveBeenCalledWith({
+			column_id: 1,
+			content_id: 'pull request 3',
+			content_type: 'PullRequest',
+		})
+	})
+})
+
+test('undo archives cards and removes data from state', async () => {
+	const state = {
+		project: { id: 'mock project id' },
+		repos: [{ card: { id: 1 } }, { card: { id: 2 } }],
+	}
+
+	await addToProject.undo({ githubAccessToken }, state)
+
+	expect(octokit.projects.updateCard).toHaveBeenCalledWith({
+		card_id: 1,
+		archived: true,
+	})
+
+	expect(octokit.projects.updateCard).toHaveBeenCalledWith({
+		card_id: 2,
+		archived: true,
+	})
+
+	expect(state.repos).toEqual([{}, {}])
+})

--- a/test/commands/add-to-project.test.js
+++ b/test/commands/add-to-project.test.js
@@ -55,12 +55,10 @@ test('undo archives cards and removes data from state', async () => {
 
 	expect(octokit.projects.deleteCard).toHaveBeenCalledWith({
 		card_id: 1,
-		archived: true,
 	})
 
 	expect(octokit.projects.deleteCard).toHaveBeenCalledWith({
 		card_id: 2,
-		archived: true,
 	})
 
 	expect(state.repos).toEqual([{}, {}])

--- a/test/commands/add-to-project.test.js
+++ b/test/commands/add-to-project.test.js
@@ -53,12 +53,12 @@ test('undo archives cards and removes data from state', async () => {
 
 	await addToProject.undo({ githubAccessToken }, state)
 
-	expect(octokit.projects.updateCard).toHaveBeenCalledWith({
+	expect(octokit.projects.deleteCard).toHaveBeenCalledWith({
 		card_id: 1,
 		archived: true,
 	})
 
-	expect(octokit.projects.updateCard).toHaveBeenCalledWith({
+	expect(octokit.projects.deleteCard).toHaveBeenCalledWith({
 		card_id: 2,
 		archived: true,
 	})

--- a/test/commands/create-project.test.js
+++ b/test/commands/create-project.test.js
@@ -1,4 +1,4 @@
-const project = require('../../src/commands/project')
+const project = require('../../src/commands/create-project')
 const getOctokit = require('../../src/lib/octokit')
 
 const githubAccessToken = 'mock access token'
@@ -59,29 +59,6 @@ describe('creating project board', () => {
 		expect(octokit.projects.createColumn).toHaveBeenCalledWith({
 			project_id,
 			name: 'Done',
-		})
-	})
-
-	test('adds every Pull Request to the board it created', async () => {
-		const column_id = (await octokit.projects.createColumn.mock.results[0]
-			.value).data.id
-
-		expect(octokit.projects.createCard).toHaveBeenCalledWith({
-			column_id,
-			content_id: 'pull request 1',
-			content_type: 'PullRequest',
-		})
-
-		expect(octokit.projects.createCard).toHaveBeenCalledWith({
-			column_id,
-			content_id: 'pull request 2',
-			content_type: 'PullRequest',
-		})
-
-		expect(octokit.projects.createCard).toHaveBeenCalledWith({
-			column_id,
-			content_id: 'pull request 3',
-			content_type: 'PullRequest',
 		})
 	})
 })

--- a/test/commands/get-project.test.js
+++ b/test/commands/get-project.test.js
@@ -1,0 +1,50 @@
+const project = require('../../src/commands/get-project')
+const getOctokit = require('../../src/lib/octokit')
+
+const githubAccessToken = 'mock access token'
+const octokit = getOctokit(githubAccessToken)
+
+test('correctly throws an error if given incorrect arguments', () => {
+	const projectUrlArg = project.args.find(arg => arg.name === 'projectUrl')
+
+	expect(projectUrlArg.validate('not a github url')).toBe(
+		'Please enter a valid GitHub organisation project URL',
+	)
+	expect(
+		projectUrlArg.validate('https://github.com/orgs/org/projects/137'),
+	).toEqual(true)
+})
+
+test('adds project board by number to state', async () => {
+	const projectUrl = 'https://github.com/orgs/org/projects/137'
+
+	const state = {}
+	await project.handler(
+		{
+			projectUrl,
+			githubAccessToken,
+		},
+		state,
+	)
+
+	expect(octokit.projects.listForOrg.endpoint.merge).toHaveBeenCalledWith({
+		org: 'org',
+	})
+
+	expect(state).toEqual({
+		project: {
+			id: 'mock project id',
+			number: 137,
+			columns: [{ id: 'mock column id' }],
+		},
+	})
+})
+
+test('undo removes data from state', async () => {
+	const state = {
+		project: { id: 'mock project id' },
+	}
+
+	await project.undo({ githubAccessToken }, state)
+	expect(state).toEqual({})
+})

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -104,7 +104,7 @@ describe('undoing pull requests', () => {
 		expect(octokit.issues.createComment).toHaveBeenCalledWith({
 			owner: 'org',
 			repo: 'repo2',
-			pull_number: 2,
+			issue_number: 2,
 			body: 'automatically closed 🤖',
 		})
 	})
@@ -113,14 +113,14 @@ describe('undoing pull requests', () => {
 		expect(octokit.pulls.update).toHaveBeenCalledWith({
 			owner: 'org',
 			repo: 'repo1',
-			number: 1,
+			pull_number: 1,
 			state: 'closed',
 		})
 
 		expect(octokit.pulls.update).toHaveBeenCalledWith({
 			owner: 'org',
 			repo: 'repo2',
-			number: 2,
+			pull_number: 2,
 			state: 'closed',
 		})
 	})

--- a/test/commands/prs.test.js
+++ b/test/commands/prs.test.js
@@ -97,14 +97,14 @@ describe('undoing pull requests', () => {
 		expect(octokit.issues.createComment).toHaveBeenCalledWith({
 			owner: 'org',
 			repo: 'repo1',
-			number: 1,
+			issue_number: 1,
 			body: 'automatically closed 🤖',
 		})
 
 		expect(octokit.issues.createComment).toHaveBeenCalledWith({
 			owner: 'org',
 			repo: 'repo2',
-			number: 2,
+			pull_number: 2,
 			body: 'automatically closed 🤖',
 		})
 	})


### PR DESCRIPTION
there's no way to get a project from the API directly by URL, and no way for a user to get the ID, so it has to list all org projects and match the URL, which needs pagination 😩 

- [x] test `get-project`
- [x] rebase once #82 is merged

closes #85, #73 