### PR TITLE
add Tako hostname validation

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -5,6 +5,10 @@ const { prompt } = require('enquirer')
 const toSentence = require('./to-sentence')
 const util = require('util')
 const mkdirp = util.promisify(require('mkdirp'))
+const {
+	validateTakoHostname,
+	formatTakoHostname,
+} = require('./is-tako-hostname')
 
 const configVars = [
 	{
@@ -17,6 +21,12 @@ const configVars = [
 		name: 'takoHost',
 		message: 'Tako hostname',
 		type: 'text',
+		validate: hostname => {
+			return validateTakoHostname(hostname)
+		},
+		result: hostname => {
+			return formatTakoHostname(hostname)
+		},
 	},
 	{
 		name: 'takoToken',

--- a/src/lib/is-tako-hostname.js
+++ b/src/lib/is-tako-hostname.js
@@ -1,0 +1,14 @@
+// checks whether the hostname has been entered into the format that Nori expects, because Nori then interpolates it into the string it uses when calling Tako.
+
+exports.validateTakoHostname = hostname => {
+	if (/^https?:\/\/([\w\d\-]+\.)+\w{2,}(\/.+)?$/.test(hostname)) {
+		if (/(https:\/\/)*([^\/]*)(\/.*)*/.test(hostname)) {
+			return true
+		}
+	}
+	return 'Please enter a valid Tako hostname, e.g. "customer-products-tako.in.ft.com"'
+}
+
+exports.formatTakoHostname = hostname => {
+	return /(https:\/\/)*([^\/]*)(\/.*)*/.exec(hostname)[2]
+}

--- a/test/lib/is-tako-hostname.test.js
+++ b/test/lib/is-tako-hostname.test.js
@@ -1,0 +1,62 @@
+const {
+	validateTakoHostname,
+	formatTakoHostname,
+} = require('../../src/lib/is-tako-hostname')
+
+test('should return hostname manipulated into correct format', () => {
+	expect(
+		validateTakoHostname('https://customer-products.in.ft.com/tako'),
+	).toEqual(true)
+
+	expect(
+		formatTakoHostname('https://customer-products.in.ft.com/tako'),
+	).toEqual('customer-products.in.ft.com')
+})
+
+test('should return hostname manipulated into correct format', () => {
+	expect(
+		validateTakoHostname('https://customer-products.in.ft.com/tako'),
+	).toEqual(true)
+
+	expect(
+		formatTakoHostname('https://customer-products.in.ft.com/tako/repositories'),
+	).toEqual('customer-products.in.ft.com')
+})
+
+test('should return hostname manipulated into correct format', () => {
+	expect(
+		validateTakoHostname('https://customer-products.in.ft.com/tako'),
+	).toEqual(true)
+
+	expect(
+		formatTakoHostname(
+			'https://https://customer-products.in.ft.com/tako/repositories',
+		),
+	).toEqual('customer-products.in.ft.com')
+})
+
+test('should return instruction to edit hostname', () => {
+	expect(
+		validateTakoHostname('https://customer-products.in.ft.com/tako'),
+	).toEqual(true)
+
+	expect(formatTakoHostname('customer-products.in.ft.com/tako/')).toEqual(
+		'customer-products.in.ft.com',
+	)
+})
+
+test('should proceed', () => {
+	expect(
+		validateTakoHostname('https://customer-products.in.ft.com/tako'),
+	).toEqual(true)
+
+	expect(formatTakoHostname('customer-products.in.ft.com')).toEqual(
+		'customer-products.in.ft.com',
+	)
+})
+
+test('requests a different hostname', () => {
+	expect(validateTakoHostname('https:customer-products.in')).toEqual(
+		'Please enter a valid Tako hostname, e.g. "customer-products-tako.in.ft.com"',
+	)
+})


### PR DESCRIPTION
It hasn't been clear what format to provide the Tako hostname in so this should ensure that only the correct/easily coerced inputs are accepted.  closes #88 