### PR TITLE
Pin enquirer dependency to v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@octokit/plugin-throttling": "^2.4.0",
 		"@octokit/rest": "^16.25.1",
 		"ansi-colors": "^3.2.4",
-		"enquirer": "^2.3.0",
+		"enquirer": "2.3.0",
 		"error-subclass": "^2.2.0",
 		"get-stdin": "^6.0.0",
 		"got": "^9.6.0",


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/nori/issues/106.

#### Globally installed
`$ npm i -g nori`
`$ npm list`: `enquirer@2.3.6`
`$ nori`
`$ ? create a session › foobar`
Results in:
```
(node:1537) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'filter' of undefined
    at MultiSelect.filter (/Users/samuel.parkinson/Repositories/Financial-Times/nori/node_modules/enquirer/lib/types/array.js:509:26)
```
My guess would be that the same thing is happening when running Nori via `npx nori`.

#### Installing and running repo locally in its current state
`$ git clone git@github.com:Financial-Times/nori.git`
`$ npm i`
`$ npm list`: `enquirer@2.3.0` (the `package.json` lists `^2.3.0` but the `package.lock` lists `2.3.0`)
`$ ? create a session › foobar`
Results in:
`? available operations … ` (i.e. no error)

#### Installing and running repo locally with v2.3.6 of `enquirer` (via pinning to that version in `package.json`)
`$ git clone git@github.com:Financial-Times/nori.git`
`$ npm i`
`$ npm list`: `enquirer@2.3.6`
`$ ? create a session › foobar`
Results in:
```
(node:1537) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'filter' of undefined
    at MultiSelect.filter (/Users/samuel.parkinson/Repositories/Financial-Times/nori/node_modules/enquirer/lib/types/array.js:509:26)
```

This is the quick fix. I am curious enough to see exactly which 2.3.x version of `enquirer` was the one where this error first appeared, and see if the changes made for that version can be accommodated by the `nori` code so that we can keep consuming updates.

What this scenario has indicated is that the `package.lock` is ignored when acquiring this tool via `npx nori` or `npm i -g nori`, which is interesting and perhaps unexpected.