### PR TITLE
CPP-326 - added nori/ prefix to branch names

### DIFF
--- a/src/commands/run-script.js
+++ b/src/commands/run-script.js
@@ -8,7 +8,7 @@ const styles = require('../lib/styles')
 const incrementSuffix = require('../lib/increment-suffix')
 const promiseAllErrors = require('../lib/promise-all-errors')
 
-const branchFormat = v => `nori/${v}`
+const formatBranch = v => `nori/${v}`
 
 exports.args = [
 	{
@@ -34,8 +34,8 @@ exports.args = [
 	{
 		type: 'text',
 		name: 'branch',
-		format: branchFormat,
-		result: branchFormat,
+		format: formatBranch,
+		result: formatBranch,
 		message: 'branch to create',
 	},
 ]

--- a/src/commands/run-script.js
+++ b/src/commands/run-script.js
@@ -8,6 +8,8 @@ const styles = require('../lib/styles')
 const incrementSuffix = require('../lib/increment-suffix')
 const promiseAllErrors = require('../lib/promise-all-errors')
 
+const branchFormat = v => `nori/${v}`
+
 exports.args = [
 	{
 		type: 'text',
@@ -29,7 +31,13 @@ exports.args = [
 			return true
 		},
 	},
-	{ type: 'text', name: 'branch', message: 'branch to create' },
+	{
+		type: 'text',
+		name: 'branch',
+		format: branchFormat,
+		result: branchFormat,
+		message: 'branch to create',
+	},
 ]
 
 /**
@@ -46,7 +54,6 @@ exports.handler = async ({ script, branch }, state) => {
 	return promiseAllErrors(
 		state.repos.map(async repository => {
 			const repoLabel = `${repository.owner}/${repository.name}`
-			const prefixedBranch = `nori/${branch}`
 
 			try {
 				// if the branch we're trying to create already exists, create `branch-1`
@@ -56,14 +63,14 @@ exports.handler = async ({ script, branch }, state) => {
 					workingDirectory: repository.clone,
 				})
 
-				const repoBranch = incrementSuffix(branches, prefixedBranch)
+				const repoBranch = incrementSuffix(branches, branch)
 
 				logger.log(repoLabel, {
 					message: `creating branch ${styles.branch(
 						repoBranch,
 					)} in ${styles.repo(repoLabel)}${
-						prefixedBranch !== repoBranch
-							? ` (${styles.branch(prefixedBranch)} already exists)`
+						branch !== repoBranch
+							? ` (${styles.branch(branch)} already exists)`
 							: ''
 					}`,
 				})

--- a/src/commands/run-script.js
+++ b/src/commands/run-script.js
@@ -46,6 +46,7 @@ exports.handler = async ({ script, branch }, state) => {
 	return promiseAllErrors(
 		state.repos.map(async repository => {
 			const repoLabel = `${repository.owner}/${repository.name}`
+			const prefixedBranch = `nori/${branch}`
 
 			try {
 				// if the branch we're trying to create already exists, create `branch-1`
@@ -55,14 +56,14 @@ exports.handler = async ({ script, branch }, state) => {
 					workingDirectory: repository.clone,
 				})
 
-				const repoBranch = incrementSuffix(branches, branch)
+				const repoBranch = incrementSuffix(branches, prefixedBranch)
 
 				logger.log(repoLabel, {
 					message: `creating branch ${styles.branch(
 						repoBranch,
 					)} in ${styles.repo(repoLabel)}${
-						branch !== repoBranch
-							? ` (${styles.branch(branch)} already exists)`
+						prefixedBranch !== repoBranch
+							? ` (${styles.branch(prefixedBranch)} already exists)`
 							: ''
 					}`,
 				})


### PR DESCRIPTION
[CPP-326 – Add prefix to nori-created branch names](https://financialtimes.atlassian.net/browse/CPP-326)

"To enable targeting CircleCI config on branch names for tasks like CPP-298, we should add a prefix to the branch names created by Nori, e.g. `nori/${user-submitted-name}`"