### PR TITLE
Retry PR creation API after rate limiting

### DIFF
--- a/src/lib/octokit.js
+++ b/src/lib/octokit.js
@@ -5,19 +5,21 @@ const OctokitInstance = Octokit.plugin(throttling, retry)
 
 let client
 
+const retryLimitOnce = (_retryAfter, options) => {
+	// Only retry once.
+	if (options.request.retryCount === 0) {
+		return true
+	}
+}
+
 module.exports = token => {
 	if (!client) {
 		client = new OctokitInstance({
 			previews: ['inertia-preview'],
 			auth: `token ${token}`,
 			throttle: {
-				onRateLimit: (retryAfter, options) => {
-					// Only retry once.
-					if (options.request.retryCount === 0) {
-						return true
-					}
-				},
-				onAbuseLimit: () => {},
+				onRateLimit: retryLimitOnce,
+				onAbuseLimit: retryLimitOnce,
 			},
 		})
 	}


### PR DESCRIPTION
We've been running into abuse limiting when creating many PRs for a workspace, presumably as a result of secondary rate limiting. We use the throttling plugin from octokit to handle standard rate limiting but it doesn't seem to catch limiting behaviour that GitHub considers more abusive. From GitHub's best practices documentation:

> Requests that create content which triggers notifications, such as
issues, comments and pull requests, may be further limited and will not
include a Retry-After header in the response. Please create this content
at a reasonable pace to avoid further limiting.

Now requests are retried at a minimum of 5 seconds after the original, which is probably what we want even if the documentation is (intentionally) vague.

Closes #149