### PR TITLE
Implement mechanism to avoid secondary rate limit on PR creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Push each repository's local branch to the remote. If a branch already exists on
 </table>
 
 ### Pull Requests
+If you are planning to raise PRs, please add your github personal access token to the githubAccessToken object in `~/.config/nori-workspace/config.json`. Authenticating increases the [secondary rate limit](https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits) of GitHub API, which increases your chance to raise multiple PRs without being blocked by the limit.
 
 ##### `nori prs --templates.title --templates.body`
 

--- a/src/commands/prs.js
+++ b/src/commands/prs.js
@@ -45,47 +45,46 @@ exports.handler = async ({ templates: { title, body } }, state) => {
 
 	const octokit = getOctokit(githubAccessToken)
 
-	await promiseAllErrors(
-		state.repos.map(async repo => {
-			if (repo.remoteBranch) {
-				const [existingPr] = await octokit.paginate(
-					octokit.pulls.list.endpoint.merge({
-						owner: repo.owner,
-						repo: repo.name,
-						head: `${repo.owner}:${repo.remoteBranch}`,
-					}),
-				)
+	for (const repo of state.repos) {
+		if (repo.remoteBranch) {
+			const [existingPr] = await octokit.paginate(
+				octokit.pulls.list.endpoint.merge({
+					owner: repo.owner,
+					repo: repo.name,
+					head: `${repo.owner}:${repo.remoteBranch}`,
+				}),
+			)
 
-				if (existingPr) {
-					logger.log(`${repo.owner}/${repo.name} PR`, {
-						status: 'info',
-						message: `using existing PR ${styles.url(
-							existingPr.html_url,
-						)} for ${styles.branch(repo.remoteBranch)} on ${styles.repo(
-							`${repo.owner}/${repo.name}`,
-						)}`,
-					})
-				}
-				repo.pr =
-					existingPr ||
-					(await logger
-						.logPromise(
-							octokit.pulls.create({
-								owner: repo.owner,
-								repo: repo.name,
-								head: repo.remoteBranch,
-								base: repo.centralBranch,
-								title: titleTemplate(repo),
-								body: bodyTemplate(repo),
-							}),
-							`creating PR for ${styles.branch(
-								repo.remoteBranch,
-							)} on ${styles.repo(`${repo.owner}/${repo.name}`)}`,
-						)
-						.then(response => response.data))
+			if (existingPr) {
+				logger.log(`${repo.owner}/${repo.name} PR`, {
+					status: 'info',
+					message: `using existing PR ${styles.url(
+						existingPr.html_url,
+					)} for ${styles.branch(repo.remoteBranch)} on ${styles.repo(
+						`${repo.owner}/${repo.name}`,
+					)}`,
+				})
 			}
-		}),
-	)
+			repo.pr =
+				existingPr ||
+				(await logger
+					.logPromise(
+						octokit.pulls.create({
+							owner: repo.owner,
+							repo: repo.name,
+							head: repo.remoteBranch,
+							base: repo.centralBranch,
+							title: titleTemplate(repo),
+							body: bodyTemplate(repo),
+						}),
+						`creating PR for ${styles.branch(
+							repo.remoteBranch,
+						)} on ${styles.repo(`${repo.owner}/${repo.name}`)}`,
+					)
+					.then(response => response.data))
+			await new Promise(r => setTimeout(r, 2000))
+		}
+	}
 }
 
 exports.undo = async (_, state) => {

--- a/src/commands/prs.js
+++ b/src/commands/prs.js
@@ -5,6 +5,8 @@ const styles = require('../lib/styles')
 const getConfig = require('../lib/config')
 const promiseAllErrors = require('../lib/promise-all-errors')
 
+const PR_CREATION_TIMEOUT_MS = 2000
+
 exports.command = 'prs'
 exports.desc = 'create Github pull requests for pushed branches'
 
@@ -82,7 +84,7 @@ exports.handler = async ({ templates: { title, body } }, state) => {
 						)} on ${styles.repo(`${repo.owner}/${repo.name}`)}`,
 					)
 					.then(response => response.data))
-			await new Promise(r => setTimeout(r, 2000))
+			await new Promise(r => setTimeout(r, PR_CREATION_TIMEOUT_MS))
 		}
 	}
 }

--- a/src/lib/octokit.js
+++ b/src/lib/octokit.js
@@ -2,6 +2,7 @@ const { Octokit } = require('@octokit/rest')
 const { throttling } = require('@octokit/plugin-throttling')
 const { retry } = require('@octokit/plugin-retry')
 const OctokitInstance = Octokit.plugin(throttling, retry)
+const logger = require('../lib/logger')
 
 let client
 
@@ -9,15 +10,28 @@ module.exports = token => {
 	if (!client) {
 		client = new OctokitInstance({
 			previews: ['inertia-preview'],
-			auth: `token ${token}`,
+			auth: token,
 			throttle: {
-				onRateLimit: (retryAfter, options) => {
-					// Only retry once.
-					if (options.request.retryCount === 0) {
-						return true
-					}
+				onRateLimit: retryAfter => {
+					logger.log(
+						`Hit GitHub API rate limit, retrying after ${retryAfter}s`,
+						{
+							status: 'pending',
+							message: `Hit GitHub API rate limit, retrying after ${retryAfter}s`,
+						},
+					)
+					return true
 				},
-				onAbuseLimit: () => {},
+				onAbuseLimit: retryAfter => {
+					logger.log(
+						`Hit secondary GitHub API rate limit, retrying after ${retryAfter}s`,
+						{
+							status: 'pending',
+							message: `Hit secondary GitHub API rate limit, retrying after ${retryAfter}s`,
+						},
+					)
+					return true
+				},
 			},
 		})
 	}


### PR DESCRIPTION
Implement timeout, retryAfter and sequential request mechanism to avoid hitting the secondary rate limit, which blocks you from creating more PRs, and repeatedly hitting the rate might result in banning of your app. 

> Error: You have exceeded a secondary rate limit and have been temporarily blocked from content creation. Please retry your request again later.

The mechanism was built upon the [best practice to avoid secondary rate limit](https://docs.github.com/en/rest/guides/best-practices-for-integrators)
1. Sequential PR creation request - `Make requests for a single user or client ID serially. Do not make requests for a single user or client ID concurrently.`
2. Retry After - `When you have been limited, use the Retry-After response header to slow down.` This change allows for retries to handle the creation of the subsequent PRs
3. Time out - `Please create this content at a reasonable pace to avoid further limiting`

Without this mechanism, I was only able to create 10 PRs and then nori will error out with the secondary rate limit. With this mechanism, I was able to successfully create 61 PRs in one go with nori. We need this change as the GitHub API has recently changed to be more defensive with its secondary rate limit, [as seen in other projects ](https://github.com/BetaHuhn/repo-file-sync-action/issues/126)