### PR TITLE
Disable stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,1 +1,0 @@
-_extends: github-apps-config-next


### PR DESCRIPTION
nori has enabled the probot stale app by pulling in our default configuration from [github-apps-config-next](https://github.com/Financial-Times/github-apps-config-next/blob/main/.github/stale.yml), which will mark PRs as stale after 60 days and then close them a week after that. Seeing as the nori repository, unfortunately, doesn't get much attention, it doesn't seem to make much sense to automatically close these PRs/issues after two months as often nobody will have had a chance to look at them within that time.