### PR TITLE
cpp-793 update bizops graphql api queries to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,11 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "nori",
 			"version": "2.0.0-beta.3",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
+				"@financial-times/biz-ops-client": "^0.8.0",
 				"@financial-times/git": "^2.1.0",
 				"@octokit/plugin-retry": "^3.0.5",
 				"@octokit/plugin-throttling": "^3.3.4",
@@ -699,6 +699,29 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@financial-times/biz-ops-client": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@financial-times/biz-ops-client/-/biz-ops-client-0.8.0.tgz",
+			"integrity": "sha512-+7AILk8tTSZFqMphU8OPQ2wbAHOBgEInmqZ1oS4riA0/zFyPYukFpEUAti6eviSdjop+y8Q98MOoXzCPYKQ/FQ==",
+			"dependencies": {
+				"http-errors": "^1.8.0",
+				"mixin-deep": "^2.0.1",
+				"node-fetch": "^2.6.1",
+				"p-ratelimit": "^0.11.0",
+				"url-join": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@financial-times/biz-ops-client/node_modules/mixin-deep": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-2.0.1.tgz",
+			"integrity": "sha512-imbHQNRglyaplMmjBLL3V5R6Bfq5oM+ivds3SKgc6oRtzErEnBUUc5No11Z2pilkUvl42gJvi285xTNswcKCMA==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@financial-times/git": {
@@ -4342,6 +4365,14 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -6152,6 +6183,21 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
 			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+		},
+		"node_modules/http-errors": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+			"dependencies": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "4.0.1",
@@ -10560,6 +10606,14 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/p-ratelimit": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/p-ratelimit/-/p-ratelimit-0.11.0.tgz",
+			"integrity": "sha512-ZnNEwvlMgW8RAGqi+hl1DB6FWa7305u/b0qAmsFSmAP0xbPxH80MhsmZpjFcbJLX00/NVcSp6/WeaLCZFwXlBw==",
+			"engines": {
+				"node": ">=6.10.3"
+			}
+		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -11681,6 +11735,11 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+		},
 		"node_modules/shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -12169,6 +12228,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/string-argv": {
@@ -12719,6 +12786,14 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/toposort": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -12946,6 +13021,11 @@
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"deprecated": "Please see https://github.com/lydell/urix#deprecated",
 			"dev": true
+		},
+		"node_modules/url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"node_modules/url-parse-lax": {
 			"version": "3.0.0",
@@ -13805,6 +13885,25 @@
 					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true,
 					"peer": true
+				}
+			}
+		},
+		"@financial-times/biz-ops-client": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@financial-times/biz-ops-client/-/biz-ops-client-0.8.0.tgz",
+			"integrity": "sha512-+7AILk8tTSZFqMphU8OPQ2wbAHOBgEInmqZ1oS4riA0/zFyPYukFpEUAti6eviSdjop+y8Q98MOoXzCPYKQ/FQ==",
+			"requires": {
+				"http-errors": "^1.8.0",
+				"mixin-deep": "^2.0.1",
+				"node-fetch": "^2.6.1",
+				"p-ratelimit": "^0.11.0",
+				"url-join": "^4.0.0"
+			},
+			"dependencies": {
+				"mixin-deep": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-2.0.1.tgz",
+					"integrity": "sha512-imbHQNRglyaplMmjBLL3V5R6Bfq5oM+ivds3SKgc6oRtzErEnBUUc5No11Z2pilkUvl42gJvi285xTNswcKCMA=="
 				}
 			}
 		},
@@ -16663,6 +16762,11 @@
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
 		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
 		"deprecation": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -18089,6 +18193,18 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
 			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+		},
+		"http-errors": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
+			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -21444,6 +21560,11 @@
 			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
 			"dev": true
 		},
+		"p-ratelimit": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/p-ratelimit/-/p-ratelimit-0.11.0.tgz",
+			"integrity": "sha512-ZnNEwvlMgW8RAGqi+hl1DB6FWa7305u/b0qAmsFSmAP0xbPxH80MhsmZpjFcbJLX00/NVcSp6/WeaLCZFwXlBw=="
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -22319,6 +22440,11 @@
 				}
 			}
 		},
+		"setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -22727,6 +22853,11 @@
 					"dev": true
 				}
 			}
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
 		},
 		"string-argv": {
 			"version": "0.0.2",
@@ -23150,6 +23281,11 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+		},
 		"toposort": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -23339,6 +23475,11 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
 			"dev": true
+		},
+		"url-join": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+			"integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
 		},
 		"url-parse-lax": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
-		"@financial-times/biz-ops-client": "^0.7.1",
+		"@financial-times/biz-ops-client": "^0.8.0",
 		"@financial-times/git": "^2.1.0",
 		"@octokit/plugin-retry": "^3.0.5",
 		"@octokit/plugin-throttling": "^3.3.4",

--- a/src/commands/graphql-repos.js
+++ b/src/commands/graphql-repos.js
@@ -41,15 +41,15 @@ function getRepositoryObject(data) {
 
 	if (foundObject === undefined) {
 		throw Error(
-			`Please query for 'Repositories' or 'repositories', for example:
+			`Please query for 'repositories', for example:
             {
-                Repositories(filter: {code_contains: "customer"}) {
+                repositories(where: {code_CONTAINS: "customer"}) {
                     name
                 }
             } 
             another example:
             {
-                Team(filter: { isActive: true, code: "platforms-customer-products" }) {
+                teams(where: { isActive: true, code: "platforms-customer-products" }) {
                     repositories {
                         name
                     }

--- a/src/commands/team-repos.js
+++ b/src/commands/team-repos.js
@@ -9,14 +9,14 @@ exports.output = 'repos'
 async function getCodeNames() {
 	const message = 'Fetching Teams from Bizops'
 	const query = `{
-        Teams(filter: { isActive: true, group: { code: "customerproducts" } }) {
+        teams(where: { isActive: true, group: { code: "customerproducts" } }) {
             code,
         }
     }`
 	logger.log(message, { status: 'pending', message })
 	try {
 		const result = await bizOps.graphQL.get(query)
-		const codeNames = result.Teams.map(team => team.code)
+		const codeNames = result.teams.map(team => team.code)
 		logger.log(message, { status: 'done', message })
 		return codeNames
 	} catch (error) {
@@ -37,7 +37,7 @@ exports.args = [
 exports.handler = async ({ teams }, state) => {
 	const message = `Fetching repos of ${teams} from Bizops`
 	const query = `{
-        Teams(filter: { isActive: true, code_in: ${JSON.stringify(teams)} }) {
+        teams(where: { isActive: true, code_IN: ${JSON.stringify(teams)} }) {
             repositories {
                 name
             }
@@ -49,7 +49,7 @@ exports.handler = async ({ teams }, state) => {
 
 	logger.log(message, { status: 'done', message })
 
-	state.repos = result.Teams.reduce((prevArray, team) => {
+	state.repos = result.teams.reduce((prevArray, team) => {
 		return prevArray.concat(
 			team.repositories.map(repo => {
 				return { owner: 'Financial-Times', name: repo.name }

--- a/src/lib/bizops.js
+++ b/src/lib/bizops.js
@@ -3,7 +3,7 @@ const logger = require('../lib/logger')
 
 exports.bizOps = new BizOpsClient({
 	apiKey: process.env.BIZ_OPS_API_KEY,
-	systemCode: 'check-repos',
+	systemCode: 'nori',
 })
 
 exports.bizOpsErrorHandler = function(error, message) {

--- a/test/commands/graphql-repos.test.js
+++ b/test/commands/graphql-repos.test.js
@@ -27,7 +27,7 @@ test('`graphql-repos` command correctly throws an error if the file extension is
 
 test('getRepositoryObject gets the correct data from nested repositories object', async () => {
 	const data = {
-		Team: {
+		team: {
 			repositories: [{ name: 'platform-scripts' }],
 		},
 	}
@@ -44,7 +44,7 @@ test('getRepositoryObject gets the correct data from nested repositories object'
 
 test('getRepositoryObject correctly throws an error if repositories are not found', async () => {
 	const data = {
-		Teams: [
+		teams: [
 			{
 				techLeads: [],
 			},
@@ -59,9 +59,7 @@ test('getRepositoryObject correctly throws an error if repositories are not foun
 
 	await expect(
 		graphql.handler({ file: 'reposgraphql.txt' }, {}),
-	).rejects.toThrow(
-		new RegExp(`Please query for 'Repositories' or 'repositories'`),
-	)
+	).rejects.toThrow(new RegExp(`Please query for 'repositories'`))
 })
 
 test('getRepositoryObject correctly throws an error if the repositories property is found but has a falsy value', async () => {
@@ -81,7 +79,7 @@ test('getRepositoryObject correctly throws an error if the repositories property
 
 test('getRepositoryObject correctly throws an error if repositories are found but they do not contain names', async () => {
 	const data = {
-		Team: {
+		team: {
 			repositories: [{ code: 'platform-scripts' }],
 		},
 	}

--- a/test/commands/team-repos.test.js
+++ b/test/commands/team-repos.test.js
@@ -12,7 +12,7 @@ afterAll(() => {
 
 test('`team-repos` command correctly sets state.repos with the data from bizops', async () => {
 	const data = {
-		Teams: [
+		teams: [
 			{
 				repositories: [{ name: 'n-messaging-client' }],
 			},
@@ -36,7 +36,7 @@ test('`team-repos` command correctly sets state.repos with the data from bizops'
 
 test('getCodeNames correctly gets the code names of teams', async () => {
 	const data = {
-		Teams: [{ code: 'platforms' }, { code: 'apps' }],
+		teams: [{ code: 'platforms' }, { code: 'apps' }],
 	}
 	bizOps.graphQL = {
 		get: jest.fn().mockReturnValue(data),


### PR DESCRIPTION
Bizops has released a v2 for its graphql api, and is switching v1 off in the summer, so we need to migrate to v2.