### PR TITLE
Upgrade to Node 14/16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,53 +1,66 @@
 references:
 
-  container_config_node: &container_config_node
+  container_config_node:
+    &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: cimg/node:12.22
+      - image: cimg/node:<< parameters.node-version >>
+    parameters:
+      node-version:
+        default: "16.14"
+        type: string
 
-  workspace_root: &workspace_root
-    ~/project
+  workspace_root: &workspace_root ~/project
 
-  attach_workspace: &attach_workspace
+  attach_workspace:
+    &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys: &npm_cache_keys
+  npm_cache_keys:
+    &npm_cache_keys
     keys:
       - node-v10-{{ arch }}-{{ checksum "package-lock.json" }}
       - node-v10-{{ arch }}-
       - node-v10- # used if checksum fails
 
-  cache_npm_cache: &cache_npm_cache
+  cache_npm_cache:
+    &cache_npm_cache
     save_cache:
-        key: node-v10-{{ arch }}-{{ checksum "package-lock.json" }}
-        paths:
+      key: node-v10-{{ arch }}-{{ checksum "package-lock.json" }}
+      paths:
         - ./node_modules/
 
-  restore_npm_cache: &restore_npm_cache
+  restore_npm_cache:
+    &restore_npm_cache
     restore_cache:
-        <<: *npm_cache_keys
+      <<: *npm_cache_keys
 
-  filters_only_main: &filters_only_main
+  filters_only_main:
+    &filters_only_main
     branches:
       only: main
 
-  filters_ignore_tags: &filters_ignore_tags
+  filters_ignore_tags:
+    &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag: &filters_version_tag
+  filters_version_tag:
+    &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
     branches:
       ignore: /.*/
 
-  filters_only_renovate_nori: &filters_only_renovate_nori
+  filters_only_renovate_nori:
+    &filters_only_renovate_nori
     branches:
       only: /(^renovate-.*|^nori/.*)/
 
-  filters_ignore_tags_renovate_nori: &filters_ignore_tags_renovate_nori
+  filters_ignore_tags_renovate_nori:
+    &filters_ignore_tags_renovate_nori
     tags:
       ignore: /.*/
     branches:
@@ -66,7 +79,9 @@ jobs:
       - checkout
       - run:
           name: Checkout next-ci-shared-helpers
-          command: git clone --depth 1 git@github.com:Financial-Times/next-ci-shared-helpers.git .circleci/shared-helpers
+          command: git clone --depth 1
+            git@github.com:Financial-Times/next-ci-shared-helpers.git
+            .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
           version: "7"
@@ -122,38 +137,66 @@ workflows:
       - build:
           filters:
             <<: *filters_ignore_tags_renovate_nori
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   build-test-publish:
     jobs:
       - build:
           filters:
             <<: *filters_version_tag
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           filters:
             <<: *filters_version_tag
           requires:
-            - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - publish:
           filters:
             <<: *filters_version_tag
           requires:
-            - test
+            - test-v<< matrix.node-version >>
+          name: publish-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   renovate-nori-build-test:
     jobs:
       - waiting-for-approval:
           type: approval
           filters:
-              <<: *filters_only_renovate_nori
+            <<: *filters_only_renovate_nori
       - build:
           requires:
-              - waiting-for-approval
+            - waiting-for-approval
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-              - build
+            - build-v<< matrix.node-version >>
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
   nightly:
     triggers:
@@ -164,10 +207,18 @@ workflows:
     jobs:
       - build:
           context: next-nightly-build
+          name: build-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
       - test:
           requires:
-            - build
+            - build-v<< matrix.node-version >>
           context: next-nightly-build
+          name: test-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
 
 notify:
   webhooks:

--- a/package.json
+++ b/package.json
@@ -1,80 +1,80 @@
 {
-	"name": "nori",
-	"version": "2.0.0-beta.3",
-	"description": "",
-	"bin": "src/index.js",
-	"scripts": {
-		"test": "npm run lint && npm run unit-test",
-		"unit-test": "jest",
-		"lint": "eslint src/ test/",
-		"lint-fix": "eslint --fix src/ test/",
-		"eslint-check": "eslint --print-config . | eslint-config-prettier-check",
-		"preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git@github.com:Financial-Times/transformation-runner.git"
-	},
-	"author": "",
-	"license": "MIT",
-	"dependencies": {
-		"@financial-times/biz-ops-client": "^0.8.0",
-		"@financial-times/git": "^2.1.0",
-		"@octokit/plugin-retry": "^3.0.5",
-		"@octokit/plugin-throttling": "^3.3.4",
-		"@octokit/rest": "^18.0.9",
-		"ansi-colors": "^3.2.4",
-		"enquirer": "2.3.0",
-		"error-subclass": "^2.2.0",
-		"get-stdin": "^6.0.0",
-		"got": "^9.6.0",
-		"immer": "^3.1.2",
-		"komatsu": "^1.3.0",
-		"mkdirp": "^0.5.5",
-		"mz": "^2.7.0",
-		"promise.allsettled": "^1.0.1",
-		"rmfr": "^2.0.0",
-		"thenify": "^3.3.1",
-		"tiny-relative-date": "^1.3.0",
-		"yargs": "^16.1.1"
-	},
-	"devDependencies": {
-		"@quarterto/eslint-config": "^1.4.0",
-		"@quarterto/prettier": "^1.1.0",
-		"check-engine": "^1.10.1",
-		"eslint": "^5.16.0",
-		"eslint-config-prettier": "^4.1.0",
-		"eslint-plugin-no-only-tests": "^2.1.0",
-		"husky": "^2.3.0",
-		"jest": "^26.6.3",
-		"jest-junit": "^12.0.0",
-		"lint-staged": "^8.1.7",
-		"memfs": "^2.15.2",
-		"prettier": "^1.17.0"
-	},
-	"engines": {
-		"node": "12.x",
-		"npm": "7.x || 8.x"
-	},
-	"eslintConfig": {
-		"extends": [
-			"@quarterto"
-		]
-	},
-	"prettier": "@quarterto/prettier",
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"lint-staged": {
-		"*.{js,json}": [
-			"prettier --write",
-			"git add"
-		]
-	},
-	"volta": {
-		"node": "12.22.5",
-		"npm": "7.20.2"
-	}
+  "name": "nori",
+  "version": "2.0.0-beta.3",
+  "description": "",
+  "bin": "src/index.js",
+  "scripts": {
+    "test": "npm run lint && npm run unit-test",
+    "unit-test": "jest",
+    "lint": "eslint src/ test/",
+    "lint-fix": "eslint --fix src/ test/",
+    "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Financial-Times/transformation-runner.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@financial-times/biz-ops-client": "^0.8.0",
+    "@financial-times/git": "^2.1.0",
+    "@octokit/plugin-retry": "^3.0.5",
+    "@octokit/plugin-throttling": "^3.3.4",
+    "@octokit/rest": "^18.0.9",
+    "ansi-colors": "^3.2.4",
+    "enquirer": "2.3.0",
+    "error-subclass": "^2.2.0",
+    "get-stdin": "^6.0.0",
+    "got": "^9.6.0",
+    "immer": "^3.1.2",
+    "komatsu": "^1.3.0",
+    "mkdirp": "^0.5.5",
+    "mz": "^2.7.0",
+    "promise.allsettled": "^1.0.1",
+    "rmfr": "^2.0.0",
+    "thenify": "^3.3.1",
+    "tiny-relative-date": "^1.3.0",
+    "yargs": "^16.1.1"
+  },
+  "devDependencies": {
+    "@quarterto/eslint-config": "^1.4.0",
+    "@quarterto/prettier": "^1.1.0",
+    "check-engine": "^1.10.1",
+    "eslint": "^5.16.0",
+    "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-no-only-tests": "^2.1.0",
+    "husky": "^2.3.0",
+    "jest": "^26.6.3",
+    "jest-junit": "^12.0.0",
+    "lint-staged": "^8.1.7",
+    "memfs": "^2.15.2",
+    "prettier": "^1.17.0"
+  },
+  "engines": {
+    "node": "14.x || 16.x",
+    "npm": "7.x || 8.x"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@quarterto"
+    ]
+  },
+  "prettier": "@quarterto/prettier",
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.{js,json}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "volta": {
+    "node": "16.14.0",
+    "npm": "7.20.2"
+  }
 }


### PR DESCRIPTION
Upgrade the repository to a newer version of Node now that Node 12 is approaching end-of-life. If this repository is a Heroku app it will be updated to Node 16, the most recent LTS release; if it is an AWS Lambda it will be updated to Node 14, the latest version supported by AWS; and if it is a library or tool it will be updated to suppport either Node 14 or Node 16 so that it can be used by either Heroku or Lambda apps. This is an automated [Nori](https://github.com/Financial-Times/nori) operation so this message can't specify which type your library is, sorry!