### PR TITLE
cpp-814 - bizops key should not be a prerequisite for running nori

### DIFF
--- a/src/commands/graphql-repos.js
+++ b/src/commands/graphql-repos.js
@@ -1,5 +1,4 @@
 const fs = require('mz/fs')
-const { bizOps, bizOpsErrorHandler } = require('../lib/bizops')
 const logger = require('../lib/logger')
 const { validateFile } = require('../lib/file-validation')
 
@@ -82,6 +81,7 @@ function getRepositoryObject(data) {
 }
 
 exports.handler = async ({ file }, state) => {
+	const { bizOps, bizOpsErrorHandler } = require('../lib/bizops')
 	const query = await fs.readFile(file, 'utf8')
 	const message = 'Executing graphQL query on bizops: \n' + query
 

--- a/src/commands/team-repos.js
+++ b/src/commands/team-repos.js
@@ -1,4 +1,3 @@
-const { bizOps, bizOpsErrorHandler } = require('../lib/bizops')
 const logger = require('../lib/logger')
 
 exports.command = 'team-repos'
@@ -7,6 +6,7 @@ exports.input = []
 exports.output = 'repos'
 
 async function getCodeNames() {
+	const { bizOps, bizOpsErrorHandler } = require('../lib/bizops')
 	const message = 'Fetching Teams from Bizops'
 	const query = `{
         teams(where: { isActive: true, group: { code: "customerproducts" } }) {
@@ -35,6 +35,7 @@ exports.args = [
 ]
 
 exports.handler = async ({ teams }, state) => {
+	const { bizOps } = require('../lib/bizops')
 	const message = `Fetching repos of ${teams} from Bizops`
 	const query = `{
         teams(where: { isActive: true, code_IN: ${JSON.stringify(teams)} }) {


### PR DESCRIPTION
Users currently need to have a biz ops api key set to run nori. This is because it's exported as an instance on the `BizOpsClient` class, and is immediately instantiated when the commands that import it are initialised when the program loads.  

This pr lazy-loads the bizops module, so that it's only instantiated when the consuming function is used. This felt like a simple way of doing it without changing too much - happier to hear better options though.