### PR TITLE
Point to new APIG portal to generate Biz Ops key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Get a list of repositories from a text file, structured as line-separated `owner
 </table>
 
 ### Get repositories through Bizops
-Before executing any of the two commands below, either through `npx nori` interactive mode, or directly through the command line, make sure you set the env variable BIZ_OPS_API_KEY. To get the key, run /bifrost in any slack channel, which will create the key in https://developer.ft.com/portal/member.
+Before executing any of the two commands below, either through `npx nori` interactive mode, or directly through the command line, make sure you set the env variable `BIZ_OPS_API_KEY`. To get the key, request a key with a Biz Ops API policy from https://apigateway.in.ft.com/key-form/developer.
 
 ##### `nori team-repos`
 This operation gets all the repositories from the team you have selected.


### PR DESCRIPTION
The `/bifrost` Slack command has been [decommissioned](https://financialtimes.slack.com/archives/C06GDS7UJ/p1667814759806939) since these docs were initially written. Let's update them to reflect the new way to get a Biz Ops key.

(Pretty sure it's fine to share that URL in a public repo? Well, too late now)