### PR TITLE
Update to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,66 +1,56 @@
 references:
 
-  container_config_node:
-    &container_config_node
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: cimg/node:<< parameters.node-version >>
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.16"
         type: string
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace:
-    &attach_workspace
+  attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys:
-    &npm_cache_keys
+  npm_cache_keys: &npm_cache_keys
     keys:
       - node-v10-{{ arch }}-{{ checksum "package-lock.json" }}
       - node-v10-{{ arch }}-
       - node-v10- # used if checksum fails
 
-  cache_npm_cache:
-    &cache_npm_cache
+  cache_npm_cache: &cache_npm_cache
     save_cache:
       key: node-v10-{{ arch }}-{{ checksum "package-lock.json" }}
       paths:
         - ./node_modules/
 
-  restore_npm_cache:
-    &restore_npm_cache
+  restore_npm_cache: &restore_npm_cache
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_main:
-    &filters_only_main
+  filters_only_main: &filters_only_main
     branches:
       only: main
 
-  filters_ignore_tags:
-    &filters_ignore_tags
+  filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag:
-    &filters_version_tag
+  filters_version_tag: &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
     branches:
       ignore: /.*/
 
-  filters_only_renovate_nori:
-    &filters_only_renovate_nori
+  filters_only_renovate_nori: &filters_only_renovate_nori
     branches:
       only: /(^renovate-.*|^nori/.*)/
 
-  filters_ignore_tags_renovate_nori:
-    &filters_ignore_tags_renovate_nori
+  filters_ignore_tags_renovate_nori: &filters_ignore_tags_renovate_nori
     tags:
       ignore: /.*/
     branches:
@@ -80,11 +70,9 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
-      - node/install-npm:
-          version: "7.20.2"
       - run:
           name: Install project dependencies
           command: npm install
@@ -145,14 +133,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   build-test-publish:
     when:
@@ -167,7 +155,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -176,13 +164,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.16
 
   renovate-nori-build-test:
     when:
@@ -201,14 +189,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   nightly:
     when:
@@ -225,7 +213,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -233,7 +221,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
 notify:
   webhooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "nori",
 			"version": "2.0.0-beta.3",
-			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@financial-times/biz-ops-client": "^0.8.0",
@@ -47,8 +47,8 @@
 				"prettier": "^1.17.0"
 			},
 			"engines": {
-				"node": "16.x",
-				"npm": "7.x || 8.x"
+				"node": "16.x || 18.x",
+				"npm": "7.x || 8.x || 9.x"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
 		"unit-test": "jest",
 		"lint": "eslint src/ test/",
 		"lint-fix": "eslint --fix src/ test/",
-		"eslint-check": "eslint --print-config . | eslint-config-prettier-check",
-		"preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+		"eslint-check": "eslint --print-config . | eslint-config-prettier-check"
 	},
 	"repository": {
 		"type": "git",
@@ -53,8 +52,8 @@
 		"prettier": "^1.17.0"
 	},
 	"engines": {
-		"node": "16.x",
-		"npm": "7.x || 8.x"
+		"node": "16.x || 18.x",
+		"npm": "7.x || 8.x || 9.x"
 	},
 	"eslintConfig": {
 		"extends": [
@@ -74,7 +73,6 @@
 		]
 	},
 	"volta": {
-		"node": "16.14.1",
-		"npm": "7.20.2"
+		"node": "18.16.0"
 	}
 }


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)